### PR TITLE
fix: don't use string.replaceAll with a RegExp 

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,10 +58,10 @@ class CLI {
 
     private generateCommandName(commandFile: string) {
         return path.relative(path.join(__dirname, this.commandsFolder), commandFile)
-            .replaceAll(/^(.*)\.(.*)?$/g, '$1')
-            .replaceAll(/^\./g, '-')
-            .replaceAll(/^[/\\]/g, '-')
-            .replaceAll(/([a-z0-9])([A-Z][a-z0-9]+)/g, '$1-$2')
+            .replace(/^(.*)\.(.*)?$/g, '$1')
+            .replace(/^\./g, '-')
+            .replace(/^[/\\]/g, '-')
+            .replace(/([a-z0-9])([A-Z][a-z0-9]+)/g, '$1-$2')
             .toLowerCase();
     }
     

--- a/packages/core/src/logging/writers/terminalWriter.ts
+++ b/packages/core/src/logging/writers/terminalWriter.ts
@@ -143,7 +143,7 @@ export class TerminalWriter implements LogWriter {
 
     private applyAutoColors(messageBody: string) {
         return messageBody
-            .replaceAll(/'([^']+)'/gs, `'${this.chalk.bold('$1')}'`)
-            .replaceAll(/\[(\d+\s*ms)\]/gs, `[${this.chalk.green('$1')}]`);
+            .replace(/'([^']+)'/gs, `'${this.chalk.bold('$1')}'`)
+            .replace(/\[(\d+\s*ms)\]/gs, `[${this.chalk.green('$1')}]`);
     }
 }


### PR DESCRIPTION
don't use string.replaceAll with a RegExp as ms-python.python replaces replaceAll with a method not supporting a RegExp as sub-string