### PR TITLE
feat: Enhance execute API request command

### DIFF
--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -1,0 +1,16 @@
+export type ArrayElement<ArrayType extends readonly unknown[]> =
+    ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+export type ValueType<Type> =
+    Type extends readonly (infer ElementType)[] ? ElementType
+    : Type extends Set<(infer SetType)> ? SetType
+    : Type extends Map<unknown, (infer MapType)> ? MapType
+    : Type;
+
+export type PropertyAccessor = string | number | symbol;
+
+export type Await<T> = T extends {
+    then(onfulfilled?: (value: infer U) => unknown): unknown;
+} ? U : T;
+
+export type AwaitReturnType<T extends (...args: any) => any> = Await<ReturnType<T>>;

--- a/packages/vscode-extension/commands.yaml
+++ b/packages/vscode-extension/commands.yaml
@@ -195,6 +195,12 @@ vlocode.execRestApi:
   when: config.vlocity.salesforce.enabled
   menus:
     - menu: commandPalette
+    - menu: explorer/context
+      when:
+        - resourceExtname == .sfhttp || resourceExtname == .http || editorLangId == sfhttp
+    - menu: explorer/context
+      when:
+        - resourceExtname == .sfhttp || resourceExtname == .http || editorLangId == sfhttp
 vlocode.retrieveMetadata:
   title: 'Salesforce: Export/Retrieve metadata from Org'
   group: v_salesforce

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -776,6 +776,11 @@
                     "when": "config.vlocity.salesforce.enabled && resourceScheme == file && resourceExtname == .apex"
                 },
                 {
+                    "command": "vlocode.execRestApi",
+                    "group": "v_salesforce",
+                    "when": "config.vlocity.salesforce.enabled && (resourceExtname == .sfhttp || resourceExtname == .http)"
+                },
+                {
                     "command": "vlocode.addToProfile",
                     "group": "v_salesforce_profile",
                     "when": "config.vlocity.salesforce.profileActionsInContextMenu && config.vlocity.salesforce.enabled && resourceScheme == file && resourceFilename =~ /(\\.object|\\.field-meta\\.xml|\\.cls|\\.cls-meta\\.xml)$/"
@@ -901,6 +906,11 @@
                     "command": "vlocode.viewInSalesforce",
                     "group": "v_salesforce",
                     "when": "vlocode.conditionalContextMenus == false || resourcePath in vlocode.metadata"
+                },
+                {
+                    "command": "vlocode.execRestApi",
+                    "group": "v_salesforce",
+                    "when": "config.vlocity.salesforce.enabled && (resourceExtname == .sfhttp || resourceExtname == .http)"
                 },
                 {
                     "command": "vlocode.addToProfile",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1275,6 +1275,11 @@
                 "language": "vldp",
                 "scopeName": "source.json",
                 "path": "./syntax/datapack.tmLanguage.json"
+            },
+            {
+                "language": "sfhttp",
+                "scopeName": "source.sfhttp",
+                "path": "./syntax/sfhttp.tmLanguage.json"
             }
         ],
         "languages": [
@@ -1289,6 +1294,16 @@
                     "*_ParentKeys.json"
                 ],
                 "configuration": "./syntax/datapack-language.json"
+            },
+            {
+                "id": "sfhttp",
+                "aliases": [
+                    "Salesforce HTTP API"
+                ],
+                "extensions": [
+                    ".sfhttp",
+                    ".http"
+                ]
             },
             {
                 "id": "xml",
@@ -1578,6 +1593,7 @@
         "vsce": "^2.15.0",
         "vscode-languageclient": "^8.1.0",
         "vscode-test": "^1.6.1",
+        "vscode-tmgrammar-test": "^0.1.2",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",
         "webpack-glob-entry": "^2.1.1",

--- a/packages/vscode-extension/src/codeLensProviders/executeApiLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProviders/executeApiLensProvider.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+
+import VlocodeService from "../lib/vlocodeService";
+import { container, injectable } from "@vlocode/core";
+
+@injectable()
+export class ExecuteApiLensProvider implements vscode.CodeLensProvider {
+
+    private regex = /^(GET|POST|PUT|DELETE|PATCH) (.*)$/i
+
+    public static register(service: VlocodeService) {
+        const lens = container.get(ExecuteApiLensProvider);
+        vscode.languages.registerCodeLensProvider({ pattern: '**/*.{api,http,sfhttp,sfapi}' }, lens);
+        vscode.languages.registerCodeLensProvider({ language: 'sfhttp' }, lens);
+    }
+
+    public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+        for (let i = 0; i < document.lineCount; i++) {
+            const line = document.lineAt(i);
+            const match = line.text.match(this.regex);
+            if (match) {
+                return [
+                    new vscode.CodeLens(line.range, {
+                        title: `Execute as Salesforce API Request (${match[1].toLowerCase()})`,
+                        tooltip: "Execute the API request described in this file on the selected Salesforce org",
+                        command: "vlocode.api.execute",
+                        arguments: [ document ]
+                    })
+                ];
+            } else if (line.text) {
+                break;
+            }
+        }
+        return [];
+    }
+}

--- a/packages/vscode-extension/src/codeLensProviders/executeApiLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProviders/executeApiLensProvider.ts
@@ -2,16 +2,21 @@ import * as vscode from 'vscode';
 
 import VlocodeService from "../lib/vlocodeService";
 import { container, injectable } from "@vlocode/core";
+import { VlocodeCommand } from '../constants';
 
 @injectable()
 export class ExecuteApiLensProvider implements vscode.CodeLensProvider {
+
+    private documentFilter : Array<vscode.DocumentFilter> = [
+        { pattern: '**/*.{api,http,sfhttp,sfapi}' },
+        { language: 'sfhttp' }
+    ];
 
     private regex = /^(GET|POST|PUT|DELETE|PATCH) (.*)$/i
 
     public static register(service: VlocodeService) {
         const lens = container.get(ExecuteApiLensProvider);
-        vscode.languages.registerCodeLensProvider({ pattern: '**/*.{api,http,sfhttp,sfapi}' }, lens);
-        vscode.languages.registerCodeLensProvider({ language: 'sfhttp' }, lens);
+        vscode.languages.registerCodeLensProvider(lens.documentFilter, lens);
     }
 
     public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
@@ -22,9 +27,9 @@ export class ExecuteApiLensProvider implements vscode.CodeLensProvider {
                 return [
                     new vscode.CodeLens(line.range, {
                         title: `Execute as Salesforce API Request (${match[1].toLowerCase()})`,
-                        tooltip: "Execute the API request described in this file on the selected Salesforce org",
-                        command: "vlocode.api.execute",
-                        arguments: [ document ]
+                        tooltip: 'Execute the API request described in this file on the selected Salesforce org',
+                        command: VlocodeCommand.execRestApi,
+                        arguments: [ document.uri ]
                     })
                 ];
             } else if (line.text) {
@@ -32,5 +37,9 @@ export class ExecuteApiLensProvider implements vscode.CodeLensProvider {
             }
         }
         return [];
+    }
+
+    public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.CodeLens | undefined {
+        return codeLens;
     }
 }

--- a/packages/vscode-extension/src/commands/datapacks/deployDatapackCommand.ts
+++ b/packages/vscode-extension/src/commands/datapacks/deployDatapackCommand.ts
@@ -10,7 +10,6 @@ import { DatapackCommand } from './datapackCommand';
 import { vscodeCommand } from '../../lib/commandRouter';
 import { VlocodeCommand } from '../../constants';
 import { VlocityDeploy } from '../../lib/vlocity/vlocityDeploy';
-import { getContext } from '../../lib/vlocodeContext';
 import { VlocodeDirectDeployment } from '../../lib/vlocity/vlocodeDirectDeploy';
 import { VlocityToolsDeployment } from '../../lib/vlocity/vlocityToolsDeploy';
 
@@ -140,7 +139,7 @@ export class DeployDatapackCommand extends DatapackCommand {
      * If the users closes the question without anwsering it it will re-popup on the next deployment.
      */
     private async suggestDeploymentModeChange() {
-        const suggestionState = getContext().globalState;
+        const suggestionState = this.context.globalState;
         const usingDirectMode = this.vlocode.config.deploymentMode === 'direct';
         const currentSuggestionState = suggestionState.get<number>(deployModeSuggestionKey);
         const allowSuggest = !currentSuggestionState || (currentSuggestionState + suggestionInterval < Date.now());

--- a/packages/vscode-extension/src/commands/datapacks/omniScriptGenerateLwc.ts
+++ b/packages/vscode-extension/src/commands/datapacks/omniScriptGenerateLwc.ts
@@ -73,7 +73,12 @@ export default class GenerateLwcCommand extends DatapackCommand {
             const metaFile = components[0].files.find(file => file.packagePath.endsWith('.js-meta.xml'))!;
             const componentPath = join(outputFolder, metaFile.packagePath.slice(0, -'-meta.xml'.length));
             void vscode.window.showTextDocument(
-                await vscode.workspace.openTextDocument (vscode.Uri.file(componentPath))
+                await vscode.workspace.openTextDocument(vscode.Uri.file(componentPath)),
+                {
+                    preview: true,
+                    preserveFocus: true,
+                    viewColumn: vscode.ViewColumn.Beside
+                }
             );
         } else {
             void vscode.window.showInformationMessage(`Generated LWC components for ${components.length} components from ${datapacks.length} DataPacks`);

--- a/packages/vscode-extension/src/commands/developerLogs/setTraceFlagsCommand.ts
+++ b/packages/vscode-extension/src/commands/developerLogs/setTraceFlagsCommand.ts
@@ -3,7 +3,6 @@ import { vscodeCommand } from '../../lib/commandRouter';
 import { SalesforceDebugLevel } from '@vlocode/salesforce';
 import { DateTime } from 'luxon';
 import * as vscode from 'vscode';
-import { getContext } from '../../lib/vlocodeContext';
 import MetadataCommand from '../metadata/metadataCommand';
 
 @vscodeCommand(VlocodeCommand.setTraceFlags)
@@ -198,17 +197,17 @@ export default class SetTraceFlagsCommand extends MetadataCommand {
         const customDebugLevels = this.getCustomDebugLevels();
         const customDebugLevel = Object.assign(debugLevel, { name, created: Date.now() });
         const updatedDebugLevels = [ ...(customDebugLevels?.slice(0, this.customDebugLevelMax - 1) ?? []), customDebugLevel ];
-        getContext().globalState.update(this.customDebugLevelKey, updatedDebugLevels);
+        this.context.globalState.update(this.customDebugLevelKey, updatedDebugLevels);
         return customDebugLevel;
     }
 
     private getCustomDebugLevels() {
-        const customLevels = getContext().globalState.get<Array<SalesforceDebugLevel & {name: string, created: number }>>(this.customDebugLevelKey);
+        const customLevels = this.context.globalState.get<Array<SalesforceDebugLevel & {name: string, created: number }>>(this.customDebugLevelKey);
         return customLevels?.sort((a,b) => b.created - a.created);
     }
 
     private deleteAllCustomDebugLevels() {
-        getContext().globalState.update(this.customDebugLevelKey, undefined);
+        this.context.globalState.update(this.customDebugLevelKey, undefined);
     }
 
     public async traceFlagsWatcher() {

--- a/packages/vscode-extension/src/commands/execRestApiCommand.ts
+++ b/packages/vscode-extension/src/commands/execRestApiCommand.ts
@@ -137,7 +137,11 @@ export default class ExecuteRestApiCommand extends MetadataCommand {
         });
 
         if (responseDocument) {
-            void vscode.window.showTextDocument(responseDocument);
+            void vscode.window.showTextDocument(responseDocument, {
+                preview: true,
+                preserveFocus: true,
+                viewColumn: vscode.ViewColumn.Beside
+            });
         }
     }
 }

--- a/packages/vscode-extension/src/commands/execRestApiCommand.ts
+++ b/packages/vscode-extension/src/commands/execRestApiCommand.ts
@@ -1,53 +1,144 @@
+import * as vscode from 'vscode';
+
+import { HttpMethod, HttpRequestInfo } from '@vlocode/salesforce';
+import { Timer } from '@vlocode/util';
+
 import { VlocodeCommand } from '../constants';
 import { vscodeCommand } from '../lib/commandRouter';
-import { HttpMethod } from '@vlocode/salesforce';
-import { Timer } from '@vlocode/util';
-import * as vscode from 'vscode';
+import { ApiRequestDocumentParser } from '../lib/salesforce/apiRequestDocumentParser';
 import MetadataCommand from './metadata/metadataCommand';
 
 @vscodeCommand(VlocodeCommand.execRestApi)
 export default class ExecuteRestApiCommand extends MetadataCommand {
-    public async execute() {
-        let url = await vscode.window.showInputBox({ placeHolder: 'Enter the Salesforce API endpoint', ignoreFocusOut: true });
+
+    private httpMethodOptions: Array<{ label: string, method: HttpMethod, allowsBody?: boolean }> = [
+        { label: 'GET', method: 'GET' },
+        { label: 'POST', method: 'POST', allowsBody: true },
+        { label: 'PATCH', method: 'PATCH', allowsBody: true },
+        { label: 'PUT', method: 'PUT', allowsBody: true },
+        { label: 'DELETE', method: 'DELETE' }
+    ];
+
+    public async execute(args?: HttpRequestInfo | vscode.Uri) {
+        if (args instanceof vscode.Uri) {
+            const document = await vscode.workspace.openTextDocument(args);
+            await this.executeRequestFromDocument(document);
+        } else if (typeof args === 'object') {
+            await this.executeRequest(args);
+        } else {
+            const request = await this.showRecentRequests() ?? await this.showRequestInput();
+            request && await this.executeRequest(request);
+        }
+    }
+
+    private async executeRequestFromDocument(document: vscode.TextDocument) {
+        const request = await ApiRequestDocumentParser.parse(document);
+        await this.executeRequest(request);
+    }
+
+    private async showRequestInput() : Promise<HttpRequestInfo | undefined> {
+        const url = await vscode.window.showInputBox({ 
+            placeHolder: 'Enter the relative Salesforce API endpoint URI',
+            ignoreFocusOut: true
+        });
+
         if (!url) {
             return;
         }
 
-        const method = await vscode.window.showQuickPick(
-            [ 'GET', 'POST' ], 
-            { placeHolder: 'Select HTTP Method', ignoreFocusOut: true }) as HttpMethod;
-        if (!method) {
+        const selectedMethod = await vscode.window.showQuickPick(
+            this.httpMethodOptions,
+            {
+                placeHolder: 'Select HTTP Method',
+                ignoreFocusOut: true
+            }
+        );
+
+        if (!selectedMethod) {
             return;
         }
 
-        // transform into valid REST API
-        if (!url.startsWith('/services')) {
-            // assume APEX rest url when not prefixed with services
-            url = `/services/apexrest/${url}`.replace(/[/]+/g, '/');
+        const body = selectedMethod.allowsBody 
+            ? await vscode.window.showInputBox({ 
+                placeHolder: 'Enter POST body',
+                ignoreFocusOut: true
+            }) : undefined;
+
+        return {
+            url,
+            method: selectedMethod.method,
+            body
+        };
+    }
+
+    private async showRecentRequests() : Promise<HttpRequestInfo | undefined> {
+        const recent = this.context.recent.get<HttpRequestInfo>('apiRequests');
+        if (!recent.length) {
+            return;
         }
 
-        let body;
-        if (method == 'POST') {
-            body = await vscode.window.showInputBox({ placeHolder: 'Enter POST body', ignoreFocusOut: true });
-            if (!body) {
-                return;
+        const options = [
+            ...recent.map(r => ({ label: `${r.method} ${r.url}`, request: r })),
+            ...[{
+                label: '',
+                kind: vscode.QuickPickItemKind.Separator
+            },{
+                label: '$(add) New request',
+                request: undefined
+            },{
+                label: '$(trashcan) Clear recent requests',
+                action: 'clear'
+            }]
+        ];
+
+        const selected = await vscode.window.showQuickPick(options, {
+            placeHolder: 'Select recent request',
+            ignoreFocusOut: true
+        });
+
+        if (selected) {
+            if ('request' in selected) {
+                return selected.request;
+            }
+
+            if ('action' in selected && selected.action === 'clear') {
+                this.context.recent.clear('apiRequests');
             }
         }
+    }
 
-        this.logger.info(`Invoking ${url} as ${method}`);
+    private async executeRequest(request: HttpRequestInfo) {
+        // normalize request
+        request.method = request.method.toUpperCase() as HttpMethod;
+        if (!request.url.startsWith('/services')) {
+            // assume APEX rest url when not prefixed with services
+            request.url = `/services/apexrest/${request.url}`.replace(/[/]+/g, '/');
+        }
+
+        // add to recent requests
+        this.context.recent.add('apiRequests', request, {
+            equals: (a, b) => a.method === b.method && a.url === b.url
+        });
+
         const timer = new Timer();
-        const connection = await this.salesforce.getJsForceConnection();
-        const request = { method, url, body };
         const response = await this.vlocode.withActivity({
-            progressTitle: `${method} ${url}...`,
+            progressTitle: `${request.method} ${request.url}...`,
             location: vscode.ProgressLocation.Notification,
             cancellable: false
-        }, () => connection.request(request));
-        this.logger.info(`${method} ${url} [${timer.stop()}]`);
+        }, async () => {
+            const connection = await this.salesforce.getJsForceConnection();
+            return await connection.request(request);
+        });
+        this.logger.info(`${request.method} ${request.url} [${timer.stop()}]`);
 
-        const responseDocument = await vscode.workspace.openTextDocument({ language: 'json', content: JSON.stringify(response, null, 4) });
+        const responseDocument = await vscode.workspace.openTextDocument({
+            language: 'json',
+            content: JSON.stringify(response, null, 4)
+        });
+
         if (responseDocument) {
             void vscode.window.showTextDocument(responseDocument);
         }
     }
 }
+

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -31,6 +31,7 @@ import { VlocityNamespaceService } from '@vlocode/vlocity';
 import { SfdxConfigWatcher } from './lib/sfdxConfigWatcher';
 
 import './commands';
+import { ExecuteApiLensProvider } from './codeLensProviders/executeApiLensProvider';
 
 /**
  * Start time of the extension set when the extension is packed by webpack when the entry point is loaded
@@ -205,16 +206,18 @@ class Vlocode {
 
         // Add apex LOG symbol provider
         try {
-            this.service.registerDisposable(vscode.languages.registerDocumentSymbolProvider({ language: 'apexlog' }, new ApexLogSymbolProvider()));
+            ApexLogSymbolProvider.register(this.service);
         } catch(err) {
             this.logger.warn(`Unable to register symbol provider for APEX logs: ${err}`);
         }
+
+        ExecuteApiLensProvider.register(this.service);
 
         // Watch conditionalContextMenus for changes
         ConfigurationManager.onConfigChange(this.service.config, 'conditionalContextMenus',
             config => vscode.commands.executeCommand('setContext', `${constants.CONTEXT_PREFIX}.conditionalContextMenus`, config.conditionalContextMenus), { initial: true });
 
-        // watch for changes 
+        // watch for changes
         void this.service.registerDisposable(container.create(WorkspaceContextDetector, 'datapacks', DatapackDetector.filter()).initialize());
         void this.service.registerDisposable(container.create(WorkspaceContextDetector, 'metadata', MetadataDetector.filter()).initialize());
         void this.service.registerDisposable(container.create(SfdxConfigWatcher).initialize());

--- a/packages/vscode-extension/src/lib/commandBase.ts
+++ b/packages/vscode-extension/src/lib/commandBase.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import VlocodeService from '../lib/vlocodeService';
 import { container, LogManager } from '@vlocode/core';
 import { Command } from '../lib/command';
-import { getContext } from '../lib/vlocodeContext';
+import { getContext, VlocodeContext } from '../lib/vlocodeContext';
 import { lazy } from '@vlocode/util';
 
 export abstract class CommandBase implements Command {
@@ -14,6 +14,10 @@ export abstract class CommandBase implements Command {
     public abstract execute(...args: any[]): any | Promise<any>;
 
     public validate?(...args: any[]): any | Promise<any>;
+
+    public get context(): VlocodeContext {
+        return getContext();
+    }
 
     protected get currentOpenDocument() : vscode.Uri | undefined {
         return vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : undefined;

--- a/packages/vscode-extension/src/lib/salesforce/apiRequestDocumentParser.ts
+++ b/packages/vscode-extension/src/lib/salesforce/apiRequestDocumentParser.ts
@@ -1,0 +1,92 @@
+import * as vscode from 'vscode';
+import { HttpMethod, HttpRequestInfo } from '@vlocode/salesforce';
+
+/**
+ * Parser for SF HTTP request documents
+ */
+export class ApiRequestDocumentParser {
+
+    private readonly documentHeaderRegex = /^(GET|POST|PUT|DELETE|PATCH) (.*)$/i;
+    private readonly documentHttpHeaderRegex = /^([a-z0-9-]+): (.*)$/i;
+
+    private readonly document: vscode.TextDocument;
+    private nextLine: number = 0;
+
+    private url: string;
+    private body: string;
+    private method: HttpMethod;
+    private headers: Record<string, string> = {};
+
+    /**
+     * Parse a HTTP request document into a HttpRequestInfo object.
+     * Will throw an error if the document is not a valid HTTP request document.
+     * @param document VSCode document to parse
+     * @returns Parsed HttpRequestInfo object
+     */
+    public static async parse(document: vscode.TextDocument) {
+        const parser = new ApiRequestDocumentParser(document);
+        await parser.parseRequestMethodAndUrl();
+        await parser.parseHeaders();
+        await parser.parseBody();
+        return parser.toRequestInfo();
+    }
+
+    private constructor(document: vscode.TextDocument) {
+        this.document = document;
+    }
+
+    private toRequestInfo() : HttpRequestInfo {
+        return {
+            url: this.url,
+            method: this.method,
+            headers: this.headers,
+            body: this.body
+        };
+    }
+
+    private hasMoreLines() {
+        return this.nextLine < this.document.lineCount;
+    }
+
+    private getNextLine() {
+        if (!this.hasMoreLines()) {
+            throw new Error('No more lines to read, reached end of document');
+        }
+        return this.document.lineAt(this.nextLine++);
+    }
+
+    private async parseRequestMethodAndUrl() {
+        while(this.hasMoreLines()) {
+            const line = this.getNextLine();
+            const match = line.text.match(this.documentHeaderRegex);
+
+            if (match) {
+                this.url = match[2];
+                this.method = match[1] as HttpMethod;
+                break;
+            } else if (line.text) {
+                throw new Error(`Expected document to start with HTTP method and URL, got ${line.text} at line ${line.lineNumber}`);
+            }
+        }
+    }
+
+    private async parseHeaders() {
+        while(this.hasMoreLines()) {
+            const line = this.getNextLine();
+            const match = line.text.match(this.documentHttpHeaderRegex);
+
+            if (match) {
+                this.headers[match[1].trim()] = match[2].trim();
+            } else if (!line.text) {
+                this.nextLine--;
+                break;
+            } else {
+                break;
+            }
+        }
+    }
+
+    private async parseBody() {
+        this.body = this.document.getText(new vscode.Range(this.nextLine, 0, this.document.lineCount, 0));
+    }
+}

--- a/packages/vscode-extension/src/lib/salesforce/debugLogViewer.ts
+++ b/packages/vscode-extension/src/lib/salesforce/debugLogViewer.ts
@@ -37,13 +37,13 @@ export class DebugLogViewer {
             const debugLog = await vscode.workspace.openTextDocument(fullLogPath);
             if (debugLog) {
                 void vscode.languages.setTextDocumentLanguage(debugLog, 'apexlog');
-                void vscode.window.showTextDocument(debugLog);
+                void vscode.window.showTextDocument(debugLog, { preview: true });
             }
         } else {
             const debugLog = await vscode.workspace.openTextDocument({ content: logBody });
             if (debugLog) {
                 void vscode.languages.setTextDocumentLanguage(debugLog, 'apexlog');
-                void vscode.window.showTextDocument(debugLog);
+                void vscode.window.showTextDocument(debugLog, { preview: true });
             }
         }
     }

--- a/packages/vscode-extension/src/lib/ui/quickPick.ts
+++ b/packages/vscode-extension/src/lib/ui/quickPick.ts
@@ -1,0 +1,120 @@
+import * as vscode from 'vscode';
+
+/**
+ * Wrapper around vscode.QuickPick that allows for easier usage of advance quick pick menus without using 
+ * the event based API of {@link vscode.QuickPick} created by the  {@link vscode.window.createQuickPick} method.
+ * @template T Type of the quick pick items
+ */
+export class QuickPick<T extends vscode.QuickPickItem> implements vscode.Disposable {
+
+    private disposables: vscode.Disposable[];
+    private acceptPromise: Promise<readonly T[] | undefined>;
+    private isVisisble = false;
+
+    public get items() : readonly T[] {
+        return this.quickPick.items;
+    }
+
+    /**
+     * Create a new quick pick menu with the specified options. Uses the {@link vscode.window.createQuickPick} method to create the quick pick.
+     *
+     * For more information on the options, see {@link vscode.QuickPickOptions} and {@link vscode.QuickPickItem}.
+     * For general details on the quick pick menu see {@link vscode.window.createQuickPick}
+     *
+     * @param items Items to show in the quick pick menu
+     * @param options Options to configure the quick pick menu
+     */
+    public static create<T extends vscode.QuickPickItem>(items: readonly T[], options?: vscode.QuickPickOptions) : QuickPick<T> {
+        const quickPick = vscode.window.createQuickPick<T>();
+        quickPick.items = items;
+        quickPick.ignoreFocusOut = options?.ignoreFocusOut ?? false;
+        quickPick.placeholder = options?.placeHolder;
+        quickPick.canSelectMany = options?.canPickMany ?? false;
+        quickPick.title = options?.title;
+        quickPick.matchOnDescription = options?.matchOnDescription ?? false;
+        quickPick.matchOnDetail = options?.matchOnDetail ?? false;
+        return new QuickPick(quickPick);
+    }
+
+    private constructor(private readonly quickPick: vscode.QuickPick<T>) {
+        this.disposables = [ quickPick ];
+        this.acceptPromise = new Promise(resolve => {
+            this.disposables.unshift(quickPick.onDidAccept(() => {
+                resolve(quickPick.selectedItems);
+            }));
+            this.disposables.unshift(quickPick.onDidHide(() => {
+                this.dispose();
+                resolve(undefined);
+            }));
+        });
+    }
+
+    public dispose(): void {
+        for (const disposable of this.disposables.slice(0)) {
+            disposable.dispose();
+        }
+        if (this.isVisisble) {
+            this.quickPick.hide();
+        }
+    }
+
+    /**
+     * Add items to the quick pick menu. Items are appended to the end of the quick pick menu.
+     * @param items Items to add to the quick pick menu.
+     */
+    public addItems(items: readonly T[]) : void {
+        this.quickPick.items = [...this.quickPick.items, ...items];
+    }
+
+    /**
+     * Remove items from the quick pick menu.
+     * @param items Items to remove from the quick pick menu.
+     */
+    public removeItem(...items: readonly T[]) : void {
+        this.quickPick.items = this.quickPick.items.filter(item => !items.includes(item));
+    }
+
+    /**
+     * Remove items from the quick pick menu based on a predicate.
+     * @param predicate Predicate that determines if an item should be removed from the quick pick menu.
+     */
+    public removeItems(predicate: (item: T) => boolean) : void {
+        this.quickPick.items = this.quickPick.items.filter(item => !predicate(item));
+    }
+
+    /**
+     * Promise that resolves when the user accepts a quick pick item. 
+     * When the user cancels the quick pick, the value `undefined` is returned.
+     * @returns Promise that resolves when the user accepts the quick pick. When the user cancels the quick pick, the value `undefined` is returned.
+     */
+    public onAccept(): Promise<T | undefined> {
+        this.quickPick.canSelectMany = false;
+        this.quickPick.show();
+        this.isVisisble = true;
+        return this.acceptPromise.then(items => items?.[0]);
+    }
+
+    /**
+     * Allows the user to select multiple items from the quick pick.
+     * @returns Promise that resolves when the user accepts the quick pick. When the user cancels the quick pick, the value `undefined` is returned.
+     */
+    public onAcceptMultiple(): Promise<readonly T[] | undefined> {
+        this.quickPick.canSelectMany = true;
+        this.quickPick.show();
+        this.isVisisble = true;
+        return this.acceptPromise;
+    }
+
+    public close(): void {
+        this.dispose();
+    }
+
+    /**
+     * Promise that resolves when the clicked on the button of a quick pick item.
+     */
+    public onTriggerItemButtom(fn: ((event: { button: vscode.QuickInputButton, item: T }) => any)) {
+        this.disposables.unshift(this.quickPick.onDidTriggerItemButton(({ button, item }) => {
+            fn({ button, item });
+        }));
+    }
+}

--- a/packages/vscode-extension/src/lib/vlocodeContext.ts
+++ b/packages/vscode-extension/src/lib/vlocodeContext.ts
@@ -102,6 +102,20 @@ class RecentItems {
             }
         }
     }
+
+    /**
+     * Remove an item from the recent items list for the specified key. When no key is specified all recent items
+     * are cleared.
+     * @param key Key to remove the recent item from
+     * @param item Item to remove from the recent items list
+     * @param options.equals Function to compare two items, when not specified the default matcher is used
+     */
+    public remove<T>(key: string, itemFn: T | ((item: T) => boolean)) {
+        const predicate = typeof itemFn === 'function' ? itemFn as ((item: T) => boolean) : ((i: T) => i === itemFn);
+        const currentValues = this.globalState.get<T[]>(`${this.recentsPrefix}:${key}`, []);
+        const newValues = currentValues.filter(item => !predicate(item));
+        this.globalState.update(`${this.recentsPrefix}:${key}`, newValues);
+    }
 }
 
 /**

--- a/packages/vscode-extension/src/lib/vlocodeContext.ts
+++ b/packages/vscode-extension/src/lib/vlocodeContext.ts
@@ -6,7 +6,9 @@ import type VlocodeService from './vlocodeService';
 /**
  * Minimal version of VScodes extension context.
  */
-class VlocodeContext {
+export class VlocodeContext {
+
+    readonly recent: RecentItems = new RecentItems(this.globalState);
 
     constructor(
         /**
@@ -42,6 +44,63 @@ class VlocodeContext {
      */
     public asAbsolutePath(relativePath: string): string {
         return path.join(this.extensionPath, relativePath);
+    }
+}
+
+class RecentItems {
+
+    private readonly recentsPrefix = 'recent:';
+
+    constructor(private readonly globalState: Memento) {
+    }
+
+    /**
+     * Get recent items for for the specified key. Recent items are stored in the global 
+     * state and are sorted by most recent first. The maximum number of recent items is 10.
+     * @param key Key to get recent items for
+     * @returns List of recent items
+     * @template T Type of the recent items
+     * 
+     * @example
+     * ```typescript
+     * const recentItems = context.getRecent<string>('myKey');
+     * ```
+     */
+    public get<T>(key: string): T[] {
+        return this.globalState.get<T[]>(`${this.recentsPrefix}:${key}`, []);
+    }
+
+    /**
+     * Add an item to the recent items list for the specified key. Recent items are stored in the global
+     * state and are sorted by most recent first. The maximum number of recent items is 10.
+     * @param key Key to add the recent item to
+     * @param item Item to add to the recent items list
+     * @param options.maxItems Maximum number of recent items to store, defaults to 10 when not specified
+     * @param options.equals Function to compare two items, when not specified the default matcher is used
+     * @returns 
+     */
+    public add<T>(key: string, item: T, options?: { maxItems?: number, equals?: (item: T, other: T) => boolean }) {
+        const currentValues = this.globalState.get<T[]>(`${this.recentsPrefix}:${key}`, []);
+        const equals = options?.equals ?? ((a, b) => a === b);
+        const newValues = [item, ...currentValues.filter(v => !equals(item, v))].slice(0, options?.maxItems ?? 10);
+        this.globalState.update(`${this.recentsPrefix}:${key}`, newValues);
+    }
+
+    /**
+     * Clear the recent items list for the specified key. When no key is specified all recent items
+     * are cleared.
+     * @param key Key to clear the recent items for
+     */
+    public clear<T>(key?: string) {
+        if (key) {
+            this.globalState.update(`${this.recentsPrefix}:${key}`, undefined);
+        } else {
+            for (const stateKey of this.globalState.keys()) {
+                if (stateKey.startsWith(`${this.recentsPrefix}:`)) {
+                    this.globalState.update(stateKey, undefined);
+                }
+            }
+        }
     }
 }
 

--- a/packages/vscode-extension/src/lib/vlocodeService.ts
+++ b/packages/vscode-extension/src/lib/vlocodeService.ts
@@ -110,8 +110,6 @@ export default class VlocodeService implements vscode.Disposable, SalesforceConn
                 if (await this.handleAuthTokenExpiredError()) {
                     this.initializePromise = undefined;
                     return this.initialize();
-                } else {
-                    debugger;
                 }
             } else if (err?.code == 'ENOTFOUND') {
                 this.logger.error(`Unable to reach Salesforce; are you connected to the internet?`);
@@ -535,7 +533,7 @@ export default class VlocodeService implements vscode.Disposable, SalesforceConn
         if (!this.isInitialized) {
             // Await service initialization
             await vscode.window.withProgress({
-                title: 'Vlocode: waiting for initialization...',
+                title: 'Vlocode: Initializing...',
                 location: vscode.ProgressLocation.Window
             }, () => this.initialize());
         }

--- a/packages/vscode-extension/src/symbolProviders/apexLogSymbolProvider.ts
+++ b/packages/vscode-extension/src/symbolProviders/apexLogSymbolProvider.ts
@@ -1,24 +1,23 @@
 import * as vscode from 'vscode';
 
-/**
- * 
-09:41:19.369 (369138479)|METHOD_ENTRY|[1]|01p0Y00000O9SLP|OrderRepository.OrderRepository()
-09:41:19.369 (369244047)|METHOD_EXIT|[1]|OrderRepository
-09:41:19.369 (369309631)|CONSTRUCTOR_ENTRY|[17]|01p0Y00000O9SLP|<init>()|OrderRepository
-09:41:19.369 (369582949)|CONSTRUCTOR_EXIT|[17]|01p0Y00000O9SLP|<init>()|OrderRepository
-09:41:19.369 (369616240)|CONSTRUCTOR_ENTRY|[17]|01p5E000001BvvA|<init>(IOrderRepository)|OrderItemsController
-09:41:19.369 (369653962)|METHOD_ENTRY|[4]|01p5E000001FJwa|VlocityController.VlocityController()
-09:41:19.369 (369667080)|METHOD_EXIT|[4]|VlocityController
-09:41:19.369 (369616240)|CONSTRUCTOR_EXIT|[17]|01p5E000001BvvA|<init>(IOrderRepository)|OrderItemsController
- */
+import { container, injectable } from '@vlocode/core';
+import VlocodeService from '../lib/vlocodeService';
 
 /**
  * Provides Symbol and Outline information for Salesforce APEX logs
  */
+@injectable()
 export class ApexLogSymbolProvider implements vscode.DocumentSymbolProvider {
 
     readonly functionPattern = /^(?<time>[\d+:.]+) \(\d+\)\|(?<type>CONSTRUCTOR|METHOD|SYSTEM_METHOD)_(?<mode>ENTRY|EXIT)\|\[\d+\]\|(?<name>.*)$/;
     readonly assignmentPattern = /^(?<time>[\d+:.]+) \(\d+\)\|VARIABLE_ASSIGNMENT\|\[\d+\]\|(?<name>.*)$/;
+
+    public static register(service: VlocodeService) {
+        const symbolProvider = container.get(ApexLogSymbolProvider);
+        service.registerDisposable(
+            vscode.languages.registerDocumentSymbolProvider({ language: 'apexlog' }, symbolProvider)
+        );
+    }
 
     public provideDocumentSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
         const symbols = this.parseSymbols(this.getDocumentLineIterator(document));

--- a/packages/vscode-extension/syntax/sfhttp.tmLanguage.json
+++ b/packages/vscode-extension/syntax/sfhttp.tmLanguage.json
@@ -1,0 +1,36 @@
+{
+    "name": "Salesforce http API",
+    "scopeName": "source.sfhttp",
+    "patterns": [{ "include": "#method-and-headers" }],
+    "repository": {
+        "method-and-headers": {
+            "patterns": [{ "include": "#method-and-url" }, { "include": "#header" }],
+            "end": "\\r?\\n\\r?\\n"
+        },
+        "method-and-url": {
+            "captures": {
+                "1": { "name": "http.sf.method" },
+                "2": { "name": "http.sf.url" }
+            },
+            "match": "(?i)^(GET|POST|PUT|DELETE|PATCH) (.*)$\\n?",
+            "name": "meta.http.sf.method-url"
+        },
+        "header": {
+            "captures": {
+                "1": { "name": "http.sf.header.name" },
+                "2": { "name": "http.sf.header.value" }
+            },
+            "match": "(?i)^([a-z]+)[ ]*:[ ]*([a-z]+)$\\n?",
+            "name": "meta.http.sf.header"
+        },
+        "comment": {
+            "captures": {
+                "1": {
+                    "name": "http.sf.method.comment"
+                }
+            },
+            "match": "(//).*$\\n?",
+            "name": "comment.line.double-slash"
+        }
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       vscode-test:
         specifier: ^1.6.1
         version: 1.6.1
+      vscode-tmgrammar-test:
+        specifier: ^0.1.2
+        version: 0.1.2
       webpack:
         specifier: ^5.88.2
         version: 5.88.2(esbuild@0.14.49)(webpack-cli@5.1.4)
@@ -2167,6 +2170,7 @@ packages:
   /@oclif/config@1.18.16:
     resolution: {integrity: sha512-VskIxVcN22qJzxRUq+raalq6Q3HUde7sokB7/xk5TqRZGEKRVbFeqdQBxDWwQeudiJEgcNiMvIFbMQ43dY37FA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@oclif/errors': 1.3.6
       '@oclif/parser': 3.8.16
@@ -2220,6 +2224,7 @@ packages:
   /@oclif/errors@1.3.6:
     resolution: {integrity: sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       clean-stack: 3.0.1
       fs-extra: 9.1.0
@@ -2252,6 +2257,7 @@ packages:
   /@oclif/parser@3.8.16:
     resolution: {integrity: sha512-jeleXSh5izmBQ6vwyCJmbFPahPpd/ajxASi25FaYAWcvwVMzP/vKAKQXKWZun6T9K/gd6ywSsTpfAXiZAjBd6g==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@oclif/errors': 1.3.6
       '@oclif/linewrap': 1.0.0
@@ -3176,7 +3182,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.88.2(webpack-cli@5.1.4)
+      webpack: 5.88.2(esbuild@0.14.49)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
@@ -3187,7 +3193,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.88.2(webpack-cli@5.1.4)
+      webpack: 5.88.2(esbuild@0.14.49)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
@@ -3202,7 +3208,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.88.2(webpack-cli@5.1.4)
+      webpack: 5.88.2(esbuild@0.14.49)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
@@ -5693,7 +5699,7 @@ packages:
       esbuild: 0.19.2
       get-tsconfig: 4.7.0
       loader-utils: 2.0.4
-      webpack: 5.88.2(webpack-cli@5.1.4)
+      webpack: 5.88.2(esbuild@0.14.49)(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
     dev: true
 
@@ -11377,6 +11383,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -13045,8 +13052,24 @@ packages:
       - supports-color
     dev: true
 
+  /vscode-textmate@7.0.4:
+    resolution: {integrity: sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==}
+    dev: true
+
   /vscode-textmate@8.0.0:
     resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
+    dev: true
+
+  /vscode-tmgrammar-test@0.1.2:
+    resolution: {integrity: sha512-tLJZMAP/NWeRwlpHzjSXx+HvjJzFltndoyR6AK9fJRGjALJX6Pg7EOiYyznpJ4TNC2eMmF3IRbcZBWzJwN+n5g==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      commander: 9.5.0
+      diff: 4.0.2
+      glob: 7.2.3
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 7.0.4
     dev: true
 
   /w3c-hr-time@1.0.2:
@@ -13138,7 +13161,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.88.2(webpack-cli@5.1.4)
+      webpack: 5.88.2(esbuild@0.14.49)(webpack-cli@5.1.4)
       webpack-merge: 5.9.0
     dev: true
 


### PR DESCRIPTION
Introduce a new codelens and grammer to `sfhttp` files. These files describe API requests and with codelens can be used to execute an API request,

The API requests executed get stored as recent items so they can easily be execute again cross workspace.