### PR TITLE
fix: resolve 4 bugs found in recent commits

### DIFF
--- a/packages/salesforce/src/salesforceDataService.ts
+++ b/packages/salesforce/src/salesforceDataService.ts
@@ -255,9 +255,10 @@ export class SalesforceDataService {
 
             for (const { index } of matchedFilters.filter(f => f.isMatch)) {
                 if (lookupResults[index]) {
-                    lookupResults[index].push(record)
+                    lookupResults[index].push(record);
+                } else {
+                    lookupResults[index] = [ record ];
                 }
-                lookupResults[index] = [ record ];
             }
         }
 

--- a/packages/vlocity-deploy/src/export/datapackExporter.ts
+++ b/packages/vlocity-deploy/src/export/datapackExporter.ts
@@ -283,7 +283,7 @@ export class DatapackExporter {
 
         // Normalize the field name and set the value, also define a getter for the original field name 
         const field = extractNamespaceAndName(fieldName);
-        const isVlocityNamespace = !!field.namespace && /$vlocity/i.test(field.namespace);
+        const isVlocityNamespace = !!field.namespace && /^vlocity/i.test(field.namespace);
         const datapackFieldName = isVlocityNamespace ? `${NAMESPACE_PLACEHOLDER}__${field.name}` : fieldName;
         datapack.data[datapackFieldName] = value;
 
@@ -351,7 +351,7 @@ export class DatapackExporter {
         // Process fields
         for (const field of this.definitions.getFieldsWith(datapack, 'processor')) {
             try {
-                datapack.data[field.name] = this.evalProcessor(field.processor, datapack, datapack.data[field.name]);
+                datapack.data[field.name] = this.evalProcessor(field.processor, datapack.data[field.name], datapack);
             } catch (e) {
                 this.logger.error(`Error processing field ${field.name} on ${datapack.schema.name}`, e);
             }

--- a/packages/vlocity/src/omnistudio/formula/evaluator.ts
+++ b/packages/vlocity/src/omnistudio/formula/evaluator.ts
@@ -341,10 +341,13 @@ class FormulaTokenizer {
                 tokens.push({ type: 'string', value: this.readString(char), start, end: this.index });
                 continue;
             }
-            if (char === '%' && this.expression.indexOf('%', this.index + 1) !== -1) {
-                const start = this.index;
-                tokens.push({ type: 'variable', value: this.readPercentVariable(), start, end: this.index });
-                continue;
+            if (char === '%') {
+                const closeIndex = this.expression.indexOf('%', this.index + 1);
+                if (closeIndex !== -1 && /^[\w.:]+$/.test(this.expression.slice(this.index + 1, closeIndex))) {
+                    const start = this.index;
+                    tokens.push({ type: 'variable', value: this.readPercentVariable(), start, end: this.index });
+                    continue;
+                }
             }
             if (/[0-9]/.test(char) || (char === '.' && /[0-9]/.test(this.expression[this.index + 1]))) {
                 const start = this.index;


### PR DESCRIPTION
- Fix evalProcessor swapped arguments (value/datapack were reversed), causing
  field processors to receive the datapack object as value and a field value
  as the datapack context, crashing on any export definition with a processor.

- Fix lookupMultiple overwriting accumulated results: push() was immediately
  discarded by an unconditional reassignment, so only the last matching record
  was kept per filter instead of all matches.

- Fix namespace regex /$vlocity/i → /^vlocity/i in setDatapackField: the $
  anchor matched end-of-string, so vlocity_cmt__ fields never matched and were
  exported with the literal namespace instead of the NAMESPACE_PLACEHOLDER.

- Fix % tokenizer treating the modulo operator as a percent-variable start
  whenever any % appears later in the expression; now validates that the
  content between the two % signs is a valid path (word chars, dots, colons)
  before treating it as a variable.

https://claude.ai/code/session_014Aj2GiCJGPFxwR1FksBYAi