### PR TITLE
fix: restore build infrastructure and eliminate duplicate builds

### DIFF
--- a/packages/apex/tsconfig.json
+++ b/packages/apex/tsconfig.json
@@ -10,5 +10,6 @@
         "skipLibCheck": true
     },
     "include": ["src/**/*.ts", "src/**/*.json"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"],
     "references": [{ "path": "../util" }, { "path": "../core" }]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,5 +8,6 @@
         "declarationMap": true
     },
     "include": ["src/**/*"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"],
     "references": [{ "path": "../util" }]
 }

--- a/packages/omniscript/tsconfig.json
+++ b/packages/omniscript/tsconfig.json
@@ -8,6 +8,7 @@
         "declarationMap": true
     },
     "include": ["src/**/*.ts", "src/**/*.json"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"],
     "references": [
         { "path": "../util" },
         { "path": "../core" },

--- a/packages/salesforce/tsconfig.json
+++ b/packages/salesforce/tsconfig.json
@@ -8,5 +8,6 @@
         "declarationMap": true
     },
     "include": ["src/**/*.ts", "src/**/*.json"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"],
     "references": [{ "path": "../util" }, { "path": "../core" }]
 }

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -7,5 +7,6 @@
         "declaration": true,
         "declarationMap": false
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"]
 }

--- a/packages/vlocity-deploy/tsconfig.json
+++ b/packages/vlocity-deploy/tsconfig.json
@@ -8,6 +8,7 @@
         "declarationMap": true
     },
     "include": ["src/**/*.ts", "src/**/*.json"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"],
     "references": [
         { "path": "../util" },
         { "path": "../core" },

--- a/packages/vlocity/tsconfig.json
+++ b/packages/vlocity/tsconfig.json
@@ -8,5 +8,6 @@
         "declarationMap": true
     },
     "include": ["src/**/*.ts", "src/**/*.json"],
+    "exclude": ["**/__tests__/**", "**/*.test.ts"],
     "references": [{ "path": "../util" }, { "path": "../core" }, { "path": "../salesforce" }]
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1627,7 +1627,7 @@
         ]
     },
     "scripts": {
-        "build": "pnpm --filter @vlocode/datamapper-editor build && pnpm pre-build && tsdown -c tsdown.config.mts",
+        "build": "pnpm pre-build && tsdown -c tsdown.config.mts",
         "watch": "pnpm build --watch",
         "pack": "vsce package --no-dependencies --allow-star-activation --allow-package-secrets npm",
         "pre-build": "tsx build/commands.ts ./package.json ./commands.yaml",

--- a/packages/vscode-extension/tsdown.config.mts
+++ b/packages/vscode-extension/tsdown.config.mts
@@ -41,7 +41,7 @@ export default defineConfig((options: UserConfig) => {
     shims: true,
     minify: false,
     treeshake: false,
-    dts: developmentBuild ? false : { build: true },
+    dts: false,
     sourcemap: developmentBuild,
     clean: !developmentBuild,
     env: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
-        "noEmit": true,
         "isolatedModules": true,
         "noUncheckedSideEffectImports": true,
         "moduleDetection": "force",


### PR DESCRIPTION
Three issues were breaking the build and causing redundant work:

1. Root tsconfig had `noEmit: true` which propagated to all library packages
   via `extends`. Composite projects (those with `composite: true`) require
   emission to produce declaration files; TypeScript throws TS6310
   "Referenced project may not disable emit" when a dependency has
   noEmit enabled. Removed it from root — the cli and vscode-extension
   packages already declare `noEmit: true` in their own tsconfigs.

2. Library package tsconfigs included test files via `src/**/*.ts`, causing
   jest globals and side-effect imports (import 'jest') to be checked at
   build time with `noUncheckedSideEffectImports: true`. Added an explicit
   `exclude` for `**/__tests__/**` and `**/*.test.ts` in each affected
   package (apex, core, omniscript, salesforce, util, vlocity, vlocity-deploy).
   Tests are compiled and type-checked by jest/ts-jest, not the build.

3. The vscode-extension build script explicitly called
   `pnpm --filter @vlocode/datamapper-editor build` before running tsdown.
   When `pack-extension` invokes `pnpm run --filter "vlocode^..." build`,
   datamapper-editor is already built by pnpm's dependency ordering (it is
   a devDependency of vlocode). The extension's own build then triggered a
   second Angular build. Removed the redundant call; pnpm's workspace
   topology now owns the ordering.

4. The vscode-extension tsdown config had `dts: { build: true }` in
   production mode, which caused rolldown-plugin-dts to fail locating
   workspace package sources via tsconfig paths. A private VSCode extension
   does not export types and needs no declaration files; set `dts: false`.

https://claude.ai/code/session_01HWGxkK5rd53acQjA9F9DsZ