### PR TITLE
ci: add PR Validate workflow (build, unit tests, CodeQL)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -4,8 +4,11 @@ name: PR Validate
 #   1. the code compiles (full workspace build)
 #   2. the unit tests pass
 #   3. basic static code analysis (CodeQL)
-# Runs independently of the full CI pipeline (ci.yml) so it also works on
-# fork PRs where SonarCloud's SONAR_TOKEN secret is not available.
+# The build + unit-test job is secret-free and runs on fork PRs too,
+# unlike ci.yml's SonarCloud step which needs the SONAR_TOKEN secret. The
+# CodeQL job only runs for same-repo PRs, because uploading results to code
+# scanning needs `security-events: write`, which GITHUB_TOKEN does not grant
+# for pull_request runs originating from forks.
 
 on:
   pull_request:
@@ -49,6 +52,9 @@ jobs:
   static-analysis:
     name: Static Analysis (CodeQL)
     runs-on: ubuntu-latest
+    # Skip on fork PRs: GITHUB_TOKEN is read-only there, so the SARIF upload
+    # to code scanning would fail. Same-repo PRs and manual runs still run it.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
       contents: read

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -6,12 +6,15 @@ name: PR Validate
 #   3. basic static code analysis (CodeQL)
 # The build + unit-test job is secret-free and runs on fork PRs too,
 # unlike ci.yml's SonarCloud step which needs the SONAR_TOKEN secret. The
-# CodeQL job only runs for same-repo PRs, because uploading results to code
-# scanning needs `security-events: write`, which GITHUB_TOKEN does not grant
-# for pull_request runs originating from forks.
+# CodeQL job only runs for same-repo PRs (uploading to code scanning needs
+# `security-events: write`, which GITHUB_TOKEN does not grant for fork PRs)
+# and on pushes to main, to keep the code-scanning baseline up to date so
+# that PR analysis only flags newly introduced alerts.
 
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
   workflow_dispatch: {}
 
@@ -26,6 +29,10 @@ jobs:
   build-and-test:
     name: Build & Unit Tests
     runs-on: ubuntu-latest
+    # On push to main the full CI pipeline (ci.yml) already builds and tests,
+    # so skip here to avoid duplicate work; the CodeQL job still runs on push
+    # to refresh its baseline.
+    if: ${{ github.event_name != 'push' }}
 
     steps:
       - name: Checkout
@@ -66,12 +73,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,71 @@
+name: PR Validate
+
+# Lightweight, secret-free gate for pull requests:
+#   1. the code compiles (full workspace build)
+#   2. the unit tests pass
+#   3. basic static code analysis (CodeQL)
+# Runs independently of the full CI pipeline (ci.yml) so it also works on
+# fork PRs where SonarCloud's SONAR_TOKEN secret is not available.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Compile (build all packages)
+        run: pnpm build
+
+      - name: Unit tests
+        run: pnpm jest --ci --verbose -i
+
+      - name: Upload test results (junit)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-validate-test-results
+          path: coverage/junit.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  static-analysis:
+    name: Static Analysis (CodeQL)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## What

Adds a new GitHub Actions workflow, `.github/workflows/pr-validate.yml`, that acts as a lightweight, **secret-free** validation gate on pull requests:

1. **Code compiles** — `pnpm build` builds every workspace package.
2. **Unit tests pass** — `pnpm jest --ci --verbose -i` (the same invocation used by `ci.yml` and documented in `AGENTS.md`).
3. **Basic static code analysis** — [CodeQL](https://codeql.github.com/) (`javascript-typescript`, `build-mode: none`), which is free for this public repo. Results surface in the repo's Security → Code scanning tab.

Reuses the existing `./.github/actions/setup-workspace` composite action for the pnpm + Node setup, so it stays consistent with the rest of CI.

## Why a separate workflow from `ci.yml`?

- **No secrets required.** `ci.yml`'s static analysis step is SonarCloud, which needs the `SONAR_TOKEN` secret and therefore can't run on fork PRs. This workflow gives external contributors a meaningful green/red signal.
- **CodeQL instead of ESLint as the gate.** `pnpm lint` currently reports 61 pre-existing errors (which is why `ci.yml` runs it with `|| true`). Making ESLint a hard gate would block every PR on existing debt, so CodeQL provides the static-analysis signal without that problem.

## Notes / follow-ups

- This overlaps with `ci.yml` (which also builds + tests on PRs). Kept separate per request for a self-contained PR gate; happy to consolidate the two into one workflow if preferred.
- `main` is not branch-protected, so these checks are informational until added as required status checks in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)