### PR TITLE
Fix DataMapper editor regressions and SFDX config creation

### DIFF
--- a/packages/util/src/__tests__/sfdx.test.ts
+++ b/packages/util/src/__tests__/sfdx.test.ts
@@ -55,4 +55,33 @@ describe('sfdx config utilities', () => {
             defaultusername: 'direct@example.com'
         });
     });
+
+    it('does not fall back to a parent config for a missing direct sfdx-config path', async () => {
+        const files = new Map<string, Buffer>([
+            ['/workspace/.sfdx/sfdx-config.json', Buffer.from(JSON.stringify({ defaultusername: 'parent@example.com' }))]
+        ]);
+        const fileSystem = {
+            readFile: jest.fn(async (fileName: string) => {
+                const content = files.get(fileName);
+                if (!content) {
+                    throw enoent(fileName);
+                }
+                return content;
+            }),
+            writeFile: jest.fn(async (fileName: string, data: Buffer) => {
+                files.set(fileName, data);
+            }),
+            mkdir: jest.fn(async () => undefined)
+        };
+
+        await sfdx.setConfig('/workspace/project/.sfdx/sfdx-config.json', { defaultusername: 'child@example.com' }, { fs: fileSystem });
+
+        expect(fileSystem.writeFile).toHaveBeenCalledWith('/workspace/project/.sfdx/sfdx-config.json', expect.any(Buffer));
+        expect(JSON.parse(files.get('/workspace/project/.sfdx/sfdx-config.json')!.toString('utf8'))).toEqual({
+            defaultusername: 'child@example.com'
+        });
+        expect(JSON.parse(files.get('/workspace/.sfdx/sfdx-config.json')!.toString('utf8'))).toEqual({
+            defaultusername: 'parent@example.com'
+        });
+    });
 });

--- a/packages/util/src/__tests__/sfdx.test.ts
+++ b/packages/util/src/__tests__/sfdx.test.ts
@@ -1,0 +1,58 @@
+import 'jest';
+import { sfdx } from '../sfdx';
+
+function enoent(path: string) {
+    return Object.assign(new Error(`ENOENT: no such file or directory, open '${path}'`), { code: 'ENOENT' });
+}
+
+describe('sfdx config utilities', () => {
+    it('creates .sfdx/sfdx-config.json when setting config without an existing file', async () => {
+        const files = new Map<string, Buffer>();
+        const fileSystem = {
+            readFile: jest.fn(async (fileName: string) => {
+                const content = files.get(fileName);
+                if (!content) {
+                    throw enoent(fileName);
+                }
+                return content;
+            }),
+            writeFile: jest.fn(async (fileName: string, data: Buffer) => {
+                files.set(fileName, data);
+            }),
+            mkdir: jest.fn(async () => undefined)
+        };
+
+        await sfdx.setConfig('/workspace/project', { defaultusername: 'test@example.com' }, { fs: fileSystem });
+
+        expect(fileSystem.mkdir).toHaveBeenCalledWith('/workspace/project/.sfdx', { recursive: true });
+        expect(fileSystem.writeFile).toHaveBeenCalledWith('/workspace/project/.sfdx/sfdx-config.json', expect.any(Buffer));
+        expect(JSON.parse(files.get('/workspace/project/.sfdx/sfdx-config.json')!.toString('utf8'))).toEqual({
+            defaultusername: 'test@example.com'
+        });
+    });
+
+    it('creates the config next to a direct sfdx-config path', async () => {
+        const files = new Map<string, Buffer>();
+        const fileSystem = {
+            readFile: jest.fn(async (fileName: string) => {
+                const content = files.get(fileName);
+                if (!content) {
+                    throw enoent(fileName);
+                }
+                return content;
+            }),
+            writeFile: jest.fn(async (fileName: string, data: Buffer) => {
+                files.set(fileName, data);
+            }),
+            mkdir: jest.fn(async () => undefined)
+        };
+
+        await sfdx.setConfig('/workspace/project/.sfdx/sfdx-config.json', { defaultusername: 'direct@example.com' }, { fs: fileSystem });
+
+        expect(fileSystem.mkdir).toHaveBeenCalledWith('/workspace/project/.sfdx', { recursive: true });
+        expect(fileSystem.writeFile).toHaveBeenCalledWith('/workspace/project/.sfdx/sfdx-config.json', expect.any(Buffer));
+        expect(JSON.parse(files.get('/workspace/project/.sfdx/sfdx-config.json')!.toString('utf8'))).toEqual({
+            defaultusername: 'direct@example.com'
+        });
+    });
+});

--- a/packages/util/src/sfdx.ts
+++ b/packages/util/src/sfdx.ts
@@ -536,8 +536,11 @@ export namespace sfdx {
         config: Partial<T>, 
         options: { fs: FileSystem, replace?: boolean } = { fs: fs }
     ) : Promise<boolean> {
+        const directConfigPath = getDirectConfigPath(folderPath);
         const configFolderPath = normalizeConfigFolderPath(folderPath);
-        const currentConfig = await getConfig(configFolderPath, { fs: options.fs });
+        const currentConfig = directConfigPath
+            ? await getConfigFile<T>(directConfigPath, options.fs)
+            : await getConfig<T>(configFolderPath, { fs: options.fs });
         const newConfig = (!currentConfig?.config || options.replace) ? config 
             : merge(deepClone(currentConfig?.config ?? {}), config);
 
@@ -545,7 +548,7 @@ export namespace sfdx {
             return false;
         }
 
-        const configPath = currentConfig?.path ?? `${configFolderPath}/${defaultConfigPath}`;
+        const configPath = directConfigPath ?? currentConfig?.path ?? `${configFolderPath}/${defaultConfigPath}`;
         if (!currentConfig?.path) {
             await createDirectory(options.fs, path.dirname(configPath));
         }
@@ -554,10 +557,27 @@ export namespace sfdx {
     }
 
     function normalizeConfigFolderPath(folderPath: string): string {
-        if (folderPath.replace(/\\/g, '/').endsWith(defaultConfigPath)) {
+        if (getDirectConfigPath(folderPath)) {
             return folderPath.slice(0, -defaultConfigPath.length).replace(/[\\/]+$/, '');
         }
         return folderPath;
+    }
+
+    function getDirectConfigPath(folderPath: string): string | undefined {
+        return folderPath.replace(/\\/g, '/').endsWith(defaultConfigPath) ? folderPath : undefined;
+    }
+
+    async function getConfigFile<T extends object>(configPath: string, fileSystem: FileSystem): Promise<{ config: T, path: string } | undefined> {
+        try {
+            return {
+                config: JSON.parse((await fileSystem.readFile(configPath)).toString('utf8')),
+                path: configPath
+            };
+        } catch (err: any) {
+            if (err?.code !== 'ENOENT') {
+                throw err;
+            }
+        }
     }
 
     async function createDirectory(fileSystem: FileSystem, directoryPath: string): Promise<void> {

--- a/packages/util/src/sfdx.ts
+++ b/packages/util/src/sfdx.ts
@@ -1,5 +1,6 @@
 import open from 'open';
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import * as salesforce from '@salesforce/core';
 import { CancellationToken } from './cancellationToken';
 import { deepClone, deepCompare, merge } from './object';
@@ -26,6 +27,8 @@ export interface SalesforceOrgInfo extends SalesforceAuthResult {
 interface FileSystem {
     readFile(path: string): Promise<Buffer>;
     writeFile(path: string, data: Buffer): Promise<void>;
+    mkdir?(path: string, options?: { recursive?: boolean }): Promise<unknown>;
+    createDirectory?(path: string): Promise<unknown>;
 }
 
 /**\
@@ -497,9 +500,7 @@ export namespace sfdx {
         let configPath: string | undefined;
         let limit = options.limit ?? 2;
 
-        if (folderPath.endsWith(defaultConfigPath)) {
-            folderPath = folderPath.slice(0, -defaultConfigPath.length);
-        }
+        folderPath = normalizeConfigFolderPath(folderPath);
 
         while(limit-- > 0) {
             try {
@@ -535,7 +536,8 @@ export namespace sfdx {
         config: Partial<T>, 
         options: { fs: FileSystem, replace?: boolean } = { fs: fs }
     ) : Promise<boolean> {
-        const currentConfig = await getConfig(folderPath, { fs: options.fs });
+        const configFolderPath = normalizeConfigFolderPath(folderPath);
+        const currentConfig = await getConfig(configFolderPath, { fs: options.fs });
         const newConfig = (!currentConfig?.config || options.replace) ? config 
             : merge(deepClone(currentConfig?.config ?? {}), config);
 
@@ -543,9 +545,27 @@ export namespace sfdx {
             return false;
         }
 
-        const configPath = currentConfig?.path ?? `${folderPath}/${defaultConfigPath}`;
+        const configPath = currentConfig?.path ?? `${configFolderPath}/${defaultConfigPath}`;
+        if (!currentConfig?.path) {
+            await createDirectory(options.fs, path.dirname(configPath));
+        }
         await options.fs.writeFile(configPath, Buffer.from(JSON.stringify(newConfig, undefined, 2)));
         return true
+    }
+
+    function normalizeConfigFolderPath(folderPath: string): string {
+        if (folderPath.replace(/\\/g, '/').endsWith(defaultConfigPath)) {
+            return folderPath.slice(0, -defaultConfigPath.length).replace(/[\\/]+$/, '');
+        }
+        return folderPath;
+    }
+
+    async function createDirectory(fileSystem: FileSystem, directoryPath: string): Promise<void> {
+        if (fileSystem.mkdir) {
+            await fileSystem.mkdir(directoryPath, { recursive: true });
+        } else if (fileSystem.createDirectory) {
+            await fileSystem.createDirectory(directoryPath);
+        }
     }
 
     export async function removeOrg(username: string) {

--- a/packages/vlocity-deploy/src/export/datapackExporter.ts
+++ b/packages/vlocity-deploy/src/export/datapackExporter.ts
@@ -1160,6 +1160,11 @@ export class DatapackExporter {
             return true;
         }
 
+        if (type.name === 'PricebookEntry' && field.name === 'CurrencyIsoCode') {
+            // Never ignore CurrencyIsoCode on PricebookEntry because it is required for multi-currency orgs
+            return false;
+        }
+
         if (DatapackExporter.UNWRITABLE_FIELDS.includes(field.name)) {
             this.logger.debug(`Ignore field ${field.name} on ${type.name} as it is unwriteable`);
             return true;

--- a/packages/vlocity/src/__tests__/datamapperExecutor.test.ts
+++ b/packages/vlocity/src/__tests__/datamapperExecutor.test.ts
@@ -73,6 +73,25 @@ describe('DataMapperFormulaEvaluator', () => {
         })).toThrow('Invalid DataMapper formula "IF(true" for result path "result"');
     });
 
+    it('can report invalid execution plan formulas as warnings', () => {
+        const executor = new DataMapperExecutor();
+        const warnings = new Array<unknown>();
+        const plan = executor.buildExecutionPlan({
+            Type: 'Transform',
+            OmniDataTransformItem: [formula('IF(true', 'result', 1)]
+        }, {
+            onWarning: warning => warnings.push(warning)
+        });
+
+        expect(plan.formulas).toHaveLength(0);
+        expect(warnings).toEqual([
+            expect.objectContaining({
+                code: 'invalidFormula',
+                message: expect.stringContaining('Skipping invalid DataMapper formula "IF(true"')
+            })
+        ]);
+    });
+
     it('evaluates documented string, list, JSON and date functions', async () => {
         const evaluator = new DataMapperFormulaEvaluator();
         const context = {
@@ -317,6 +336,160 @@ describe('DataMapperExecutor', () => {
         expect(queries[0]).toContain('Id IN (\'A1\', \'A2\')');
         expect(queries[0]).toContain('ParentId = null');
         expect(queries[0]).toContain('Name LIKE \'%Acme%\'');
+    });
+
+    it('skips extract queries when a path-shaped filter reference is unresolved', async () => {
+        const mapper: DataMapperDefinition = {
+            Type: 'Extract',
+            InputType: 'JSON',
+            OutputType: 'JSON',
+            OmniDataTransformItem: [
+                extract(
+                    'QuoteLinerelationship__c',
+                    'QuoteLineItemId__c',
+                    'SBQQ__Quote__c:SBQQ__QuoteLine__c:Id',
+                    'SBQQ__Quote__c:SBQQ__QuoteLine__c:QuoteLinerelationship__c',
+                    3
+                ),
+                map(
+                    'SBQQ__Quote__c:SBQQ__QuoteLine__c:QuoteLinerelationship__c:Role__c',
+                    'relationships:role'
+                )
+            ]
+        };
+        const queries = new Array<string>();
+        const warnings = new Array<unknown>();
+
+        const result = await new DataMapperExecutor().execute(mapper, {}, {
+            queryRunner: {
+                async query(query) {
+                    queries.push(query);
+                    return [];
+                }
+            },
+            onWarning: warning => warnings.push(warning)
+        });
+
+        expect(queries).toHaveLength(0);
+        expect(result).toEqual({});
+        expect(warnings).toEqual([
+            expect.objectContaining({
+                code: 'unresolvedFilter',
+                fieldName: 'QuoteLineItemId__c',
+                objectName: 'QuoteLinerelationship__c',
+                message: expect.stringContaining('SBQQ__Quote__c:SBQQ__QuoteLine__c:Id')
+            })
+        ]);
+    });
+
+    it('keeps quoted path-shaped filter values as constants', async () => {
+        const mapper: DataMapperDefinition = {
+            Type: 'Extract',
+            InputType: 'JSON',
+            OutputType: 'JSON',
+            OmniDataTransformItem: [
+                extract(
+                    'QuoteLinerelationship__c',
+                    'QuoteLineItemId__c',
+                    '"SBQQ__Quote__c:SBQQ__QuoteLine__c:Id"',
+                    'QuoteLinerelationship__c',
+                    1
+                )
+            ]
+        };
+        const queries = new Array<string>();
+
+        await new DataMapperExecutor().execute(mapper, {}, {
+            queryRunner: {
+                async query(query) {
+                    queries.push(query);
+                    return [];
+                }
+            }
+        });
+
+        expect(queries[0]).toContain('WHERE QuoteLineItemId__c = \'SBQQ__Quote__c:SBQQ__QuoteLine__c:Id\'');
+    });
+
+    it('filters invalid extracted fields from SOQL and resolves them as null for formulas', async () => {
+        const mapper: DataMapperDefinition = {
+            Type: 'Extract',
+            InputType: 'JSON',
+            OutputType: 'JSON',
+            IsNullInputsIncludedInOutput: true,
+            OmniDataTransformItem: [
+                extract(
+                    'QuoteLinerelationship__c',
+                    'QuoteLineItemId__c',
+                    '"QL1"',
+                    'QuoteLinerelationship__c',
+                    1
+                ),
+                formula(
+                    'QuoteLinerelationship__c:RelatedQuoteLineItemId__r.Role__c',
+                    'QuoteLinerelationship__c:Role__c',
+                    1
+                ),
+                map('QuoteLinerelationship__c:Role__c', 'relationships:role')
+            ]
+        };
+        const queries = new Array<string>();
+        const warnings = new Array<unknown>();
+
+        const result = await new DataMapperExecutor().execute(mapper, {}, {
+            queryRunner: {
+                async query(query) {
+                    queries.push(query);
+                    return [{ Id: 'R1', QuoteLineItemId__c: 'QL1' }];
+                }
+            },
+            validateField: (_objectName, fieldName) => fieldName !== 'RelatedQuoteLineItemId__r.Role__c',
+            onWarning: warning => warnings.push(warning)
+        });
+
+        expect(queries[0]).toContain('SELECT Id, QuoteLineItemId__c FROM QuoteLinerelationship__c');
+        expect(queries[0]).not.toContain('RelatedQuoteLineItemId__r.Role__c');
+        expect(result).toEqual({
+            relationships: [{
+                role: null
+            }]
+        });
+        expect(warnings).toEqual([
+            expect.objectContaining({
+                code: 'invalidField',
+                fieldName: 'RelatedQuoteLineItemId__r.Role__c',
+                objectName: 'QuoteLinerelationship__c'
+            })
+        ]);
+    });
+
+    it('reports formula evaluation failures as warnings when a warning sink is provided', async () => {
+        const mapper: DataMapperDefinition = {
+            Type: 'Transform',
+            InputType: 'JSON',
+            OutputType: 'JSON',
+            OmniDataTransformItem: [
+                formula('UNKNOWN(account:name)', 'account:bad', 1),
+                map('account:bad', 'customer:bad')
+            ]
+        };
+        const warnings = new Array<unknown>();
+
+        const result = await new DataMapperExecutor().execute(mapper, {
+            account: {
+                name: 'Acme'
+            }
+        }, {
+            onWarning: warning => warnings.push(warning)
+        });
+
+        expect(result).toEqual({});
+        expect(warnings).toEqual([
+            expect.objectContaining({
+                code: 'formulaEvaluationFailed',
+                expression: 'UNKNOWN(account:name)'
+            })
+        ]);
     });
 
     it('executes extract mappers with hierarchical output and formula-created children', async () => {

--- a/packages/vlocity/src/__tests__/datamapperExecutor.test.ts
+++ b/packages/vlocity/src/__tests__/datamapperExecutor.test.ts
@@ -382,6 +382,59 @@ describe('DataMapperExecutor', () => {
         ]);
     });
 
+    it('throws for unresolved path-shaped extract filters without a warning sink', async () => {
+        const mapper: DataMapperDefinition = {
+            Type: 'Extract',
+            InputType: 'JSON',
+            OutputType: 'JSON',
+            OmniDataTransformItem: [
+                extract(
+                    'QuoteLinerelationship__c',
+                    'QuoteLineItemId__c',
+                    'SBQQ__Quote__c:SBQQ__QuoteLine__c:Id',
+                    'SBQQ__Quote__c:SBQQ__QuoteLine__c:QuoteLinerelationship__c',
+                    3
+                )
+            ]
+        };
+        const queries = new Array<string>();
+
+        await expect(new DataMapperExecutor().execute(mapper, {}, {
+            queryRunner: {
+                async query(query) {
+                    queries.push(query);
+                    return [];
+                }
+            }
+        })).rejects.toThrow('Filter QuoteLineItemId__c references unresolved DataMapper path "SBQQ__Quote__c:SBQQ__QuoteLine__c:Id"');
+        expect(queries).toHaveLength(0);
+    });
+
+    it('keeps colon-containing filter literals as constants', async () => {
+        const mapper = DataMapperBuilder.extract()
+            .extractObject('Account', 'account')
+            .where('Website', 'Equals', 'https://example.com/account:a')
+            .where('Preferred_Time__c', 'Equals', '12:30')
+            .where('ExternalKey__c', 'Equals', 'tenant:region:code')
+            .done()
+            .map('account:Name', 'accounts:name')
+            .build();
+        const queries = new Array<string>();
+
+        await new DataMapperExecutor().execute(mapper, {}, {
+            queryRunner: {
+                async query(query) {
+                    queries.push(query);
+                    return [];
+                }
+            }
+        });
+
+        expect(queries[0]).toContain("Website = 'https://example.com/account:a'");
+        expect(queries[0]).toContain("Preferred_Time__c = '12:30'");
+        expect(queries[0]).toContain("ExternalKey__c = 'tenant:region:code'");
+    });
+
     it('keeps quoted path-shaped filter values as constants', async () => {
         const mapper: DataMapperDefinition = {
             Type: 'Extract',

--- a/packages/vlocity/src/datamapper/executor.ts
+++ b/packages/vlocity/src/datamapper/executor.ts
@@ -445,13 +445,17 @@ export class DataMapperExecutor {
             const resolution = this.resolveFilterValues(condition.value, sourceTree);
             const values = uniqueValues(resolution.values);
             if (resolution.unresolved || (resolution.reference && !values.length && !isNullOperator(condition.operator))) {
+                const message = `Filter ${condition.fieldName} references unresolved DataMapper path "${resolution.reference}".`;
+                if (!options.onWarning) {
+                    throw new Error(message);
+                }
                 this.warn(options, {
                     code: 'unresolvedFilter',
                     objectName: group.objectName,
                     fieldName: condition.fieldName,
                     outputPath: group.outputPath,
                     sequence: group.sequence,
-                    message: `Skipping ${group.objectName} extract step ${group.sequence} because filter ${condition.fieldName} references unresolved path "${resolution.reference}".`
+                    message: `Skipping ${group.objectName} extract step ${group.sequence} because ${message}`
                 });
                 return { where: '', skip: true };
             }
@@ -907,7 +911,23 @@ function isQuoted(value: string) {
 }
 
 function looksLikeDataMapperReference(value: string) {
-    return value.includes(':') || /\|\d+$|\|n$/i.test(value);
+    const path = splitDataMapperPath(value);
+    return path.some(isIndexedDataMapperPathSegment)
+        || (path.length >= 2 && path.every(isDataMapperPathSegment) && path.some(isStructuredDataMapperPathSegment));
+}
+
+function isIndexedDataMapperPathSegment(segment: string) {
+    return /\|(\d+|n)$/i.test(segment) && isDataMapperPathSegment(segment);
+}
+
+function isDataMapperPathSegment(segment: string) {
+    const name = segment.replace(/\|(\d+|n)$/i, '');
+    return /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/.test(name);
+}
+
+function isStructuredDataMapperPathSegment(segment: string) {
+    const name = segment.replace(/\|(\d+|n)$/i, '');
+    return name.includes('.') || /__(c|r)(\.|$)/i.test(name);
 }
 
 function setPath(target: Record<string, unknown>, path: string, value: unknown, listFormat: boolean): void {

--- a/packages/vlocity/src/datamapper/executor.ts
+++ b/packages/vlocity/src/datamapper/executor.ts
@@ -13,6 +13,7 @@ import type {
     DataMapperDefinition,
     DataMapperExecutionOptions,
     DataMapperExecutionPlan,
+    DataMapperExecutionWarning,
     DataMapperExtractGroup,
     DataMapperFormulaStep,
     DataMapperItem,
@@ -39,10 +40,28 @@ interface OutputContainer {
     readonly children: Map<string, OutputContainer>;
 }
 
+interface BuiltExtractQuery {
+    readonly soql: string;
+    readonly invalidFields: readonly string[];
+}
+
+interface FilterValueResolution {
+    readonly values: unknown[];
+    readonly reference?: string;
+    readonly unresolved?: boolean;
+}
+
+interface WhereResult {
+    readonly where: string;
+    readonly skip: boolean;
+}
+
+const formulaEvaluationFailed = Symbol('formulaEvaluationFailed');
+
 export class DataMapperExecutor {
     private readonly formulas = new OmniStudioFormulaEvaluator();
 
-    public buildExecutionPlan(definition: DataMapperDefinition): DataMapperExecutionPlan {
+    public buildExecutionPlan(definition: DataMapperDefinition, options: Pick<DataMapperExecutionOptions, 'onWarning'> = {}): DataMapperExecutionPlan {
         const data = this.getDefinitionData(definition);
         const type = String(data.Type ?? data.type ?? 'Extract').toLowerCase();
         const normalizedType = type.includes('load') ? 'load' : type.includes('transform') ? 'transform' : 'extract';
@@ -61,9 +80,20 @@ export class DataMapperExecutor {
                         dependencies: this.formulas.dependencies(item.formulaExpression!)
                     };
                 } catch (error) {
+                    if (options.onWarning) {
+                        this.warn(options, {
+                            code: 'invalidFormula',
+                            expression: item.formulaExpression,
+                            outputPath: item.formulaResultPath,
+                            sequence: item.formulaSequence,
+                            message: `Skipping invalid DataMapper formula "${item.formulaExpression}" for result path "${item.formulaResultPath}": ${getErrorMessage(error)}`
+                        });
+                        return;
+                    }
                     throw new Error(`Invalid DataMapper formula "${item.formulaExpression}" for result path "${item.formulaResultPath}": ${getErrorMessage(error)}`);
                 }
             })
+            .filter((formula): formula is DataMapperFormulaStep => !!formula)
             .sort((a, b) => a.sequence - b.sequence);
         const extractGroups = normalizedType === 'extract' ? this.createExtractGroups(items, formulas) : [];
         const mappings = items
@@ -89,7 +119,7 @@ export class DataMapperExecutor {
     }
 
     public async execute(definition: DataMapperDefinition, inputJson: unknown, options: DataMapperExecutionOptions = {}): Promise<unknown> {
-        const plan = this.buildExecutionPlan(definition);
+        const plan = this.buildExecutionPlan(definition, options);
         if (plan.type === 'load') {
             throw new Error('DataMapper Load execution is not supported because it requires Salesforce DML side effects');
         }
@@ -109,8 +139,12 @@ export class DataMapperExecutor {
         }
         const tree: SourceTree = { input: inputJson, roots: [] };
         for (const group of plan.extractGroups) {
-            const query = this.buildQuery(group, tree);
-            const records = await options.queryRunner.query(query);
+            const query = await this.buildQuery(group, tree, options);
+            if (!query) {
+                continue;
+            }
+            const records = await options.queryRunner.query(query.soql);
+            this.applyInvalidFieldNulls(records, query.invalidFields);
             this.attachExtractRecords(tree, group, records);
         }
         return tree;
@@ -135,6 +169,9 @@ export class DataMapperExecutor {
             const nodes = this.findNodes(sourceTree, nodePath);
             for (const node of nodes) {
                 const value = await this.evaluateFormula(formula, sourceTree, node, plan, options);
+                if (value === formulaEvaluationFailed) {
+                    continue;
+                }
                 if (fieldPath) {
                     if (plan.type === 'transform' && !nodePath.length) {
                         setDataMapperPathValue(node.record, fieldPath, value);
@@ -153,7 +190,7 @@ export class DataMapperExecutor {
         node: SourceNode,
         plan: DataMapperExecutionPlan,
         options: DataMapperExecutionOptions
-    ): Promise<unknown> {
+    ): Promise<unknown | typeof formulaEvaluationFailed> {
         try {
             return await this.formulas.evaluate(formula.expression, {
                 source: node.record,
@@ -164,6 +201,16 @@ export class DataMapperExecutor {
                 resolvePath: path => this.resolveFormulaPath(sourceTree, node, path, plan)
             });
         } catch (error) {
+            if (options.onWarning) {
+                this.warn(options, {
+                    code: 'formulaEvaluationFailed',
+                    expression: formula.expression,
+                    outputPath: formula.resultPath,
+                    sequence: formula.sequence,
+                    message: `DataMapper formula "${formula.expression}" failed for result path "${formula.resultPath}": ${getErrorMessage(error)}`
+                });
+                return formulaEvaluationFailed;
+            }
             throw new Error(`DataMapper formula "${formula.expression}" failed for result path "${formula.resultPath}": ${getErrorMessage(error)}`);
         }
     }
@@ -369,55 +416,139 @@ export class DataMapperExecutor {
         return getDataMapperPathValue(sourceTree.input, path);
     }
 
-    private buildQuery(group: DataMapperExtractGroup, sourceTree: SourceTree): string {
-        const fields = group.fields.length ? group.fields : ['Id'];
-        const where = this.buildWhere(group, sourceTree);
+    private async buildQuery(group: DataMapperExtractGroup, sourceTree: SourceTree, options: DataMapperExecutionOptions): Promise<BuiltExtractQuery | undefined> {
+        const { fields, invalidFields } = await this.resolveQueryFields(group, options);
+        const where = this.buildWhere(group, sourceTree, options);
+        if (where.skip) {
+            return;
+        }
         const orderBy = group.conditions.find(condition => condition.operator === 'ORDER BY')?.value;
         const limit = group.conditions.find(condition => condition.operator === 'LIMIT')?.value;
         const offset = group.conditions.find(condition => condition.operator === 'OFFSET')?.value;
-        return [
-            `SELECT ${fields.join(', ')}`,
-            `FROM ${group.objectName}`,
-            where ? `WHERE ${where}` : '',
-            orderBy ? `ORDER BY ${orderBy}` : '',
-            limit ? `LIMIT ${Number(limit)}` : '',
-            offset ? `OFFSET ${Number(offset)}` : ''
-        ].filter(Boolean).join(' ');
+        return {
+            soql: [
+                `SELECT ${fields.join(', ')}`,
+                `FROM ${group.objectName}`,
+                where.where ? `WHERE ${where.where}` : '',
+                orderBy ? `ORDER BY ${orderBy}` : '',
+                limit ? `LIMIT ${Number(limit)}` : '',
+                offset ? `OFFSET ${Number(offset)}` : ''
+            ].filter(Boolean).join(' '),
+            invalidFields
+        };
     }
 
-    private buildWhere(group: DataMapperExtractGroup, sourceTree: SourceTree): string {
+    private buildWhere(group: DataMapperExtractGroup, sourceTree: SourceTree, options: DataMapperExecutionOptions): WhereResult {
         const conditions = group.conditions.filter(condition => !isSpecialFilter(condition.operator) && condition.fieldName);
         const groups = new Map<number, string[]>();
         for (const condition of conditions) {
-            const values = uniqueValues(this.resolveFilterValues(condition.value, sourceTree));
+            const resolution = this.resolveFilterValues(condition.value, sourceTree);
+            const values = uniqueValues(resolution.values);
+            if (resolution.unresolved || (resolution.reference && !values.length && !isNullOperator(condition.operator))) {
+                this.warn(options, {
+                    code: 'unresolvedFilter',
+                    objectName: group.objectName,
+                    fieldName: condition.fieldName,
+                    outputPath: group.outputPath,
+                    sequence: group.sequence,
+                    message: `Skipping ${group.objectName} extract step ${group.sequence} because filter ${condition.fieldName} references unresolved path "${resolution.reference}".`
+                });
+                return { where: '', skip: true };
+            }
             const expression = formatCondition(condition.fieldName!, condition.operator, values);
             const current = groups.get(condition.filterGroup) ?? [];
             current.push(expression);
             groups.set(condition.filterGroup, current);
         }
-        return [...groups.values()].map(groupConditions =>
-            groupConditions.length > 1 ? `(${groupConditions.join(' AND ')})` : groupConditions[0]
-        ).join(' OR ');
+        return {
+            where: [...groups.values()].map(groupConditions =>
+                groupConditions.length > 1 ? `(${groupConditions.join(' AND ')})` : groupConditions[0]
+            ).join(' OR '),
+            skip: false
+        };
     }
 
-    private resolveFilterValues(value: string | undefined, sourceTree: SourceTree): unknown[] {
+    private resolveFilterValues(value: string | undefined, sourceTree: SourceTree): FilterValueResolution {
         if (!value) {
-            return [undefined];
+            return { values: [undefined] };
         }
-        if (isQuoted(value)) {
-            return [value.slice(1, -1)];
+        const normalizedValue = value.trim();
+        if (isQuoted(normalizedValue)) {
+            return { values: [normalizedValue.slice(1, -1)] };
         }
-        const constant = resolveDataMapperConstant(value);
+        const constant = resolveDataMapperConstant(normalizedValue);
         if (constant.resolved) {
-            return [constant.value];
+            return { values: [constant.value] };
         }
-        const path = splitDataMapperPath(value);
+        const path = splitDataMapperPath(normalizedValue);
         const matchingGroupPath = this.findKnownSourcePath(sourceTree, path);
         if (matchingGroupPath.length) {
             const fieldPath = joinDataMapperPath(path.slice(matchingGroupPath.length));
-            return this.findNodes(sourceTree, matchingGroupPath).map(node => getRecordFieldValue(node.record, fieldPath));
+            return {
+                values: this.findNodes(sourceTree, matchingGroupPath).map(node => getRecordFieldValue(node.record, fieldPath)),
+                reference: normalizedValue
+            };
         }
-        return [getDataMapperPathValue(sourceTree.input, value) ?? value];
+        const inputValue = getDataMapperPathValue(sourceTree.input, normalizedValue);
+        if (inputValue !== undefined) {
+            return { values: [inputValue], reference: normalizedValue };
+        }
+        if (looksLikeDataMapperReference(normalizedValue)) {
+            return { values: [], reference: normalizedValue, unresolved: true };
+        }
+        return { values: [normalizedValue] };
+    }
+
+    private async resolveQueryFields(group: DataMapperExtractGroup, options: DataMapperExecutionOptions): Promise<{ fields: string[]; invalidFields: string[] }> {
+        const requestedFields = group.fields.length ? group.fields : ['Id'];
+        if (!options.validateField) {
+            return { fields: requestedFields, invalidFields: [] };
+        }
+
+        const fields = new Array<string>();
+        const invalidFields = new Array<string>();
+        for (const fieldName of requestedFields) {
+            try {
+                if (await options.validateField(group.objectName, fieldName, {
+                    objectName: group.objectName,
+                    fieldName,
+                    outputPath: group.outputPath,
+                    sequence: group.sequence
+                })) {
+                    fields.push(fieldName);
+                    continue;
+                }
+                invalidFields.push(fieldName);
+                this.warn(options, {
+                    code: 'invalidField',
+                    objectName: group.objectName,
+                    fieldName,
+                    outputPath: group.outputPath,
+                    sequence: group.sequence,
+                    message: `Skipping invalid field "${fieldName}" on ${group.objectName}; preview will resolve it as null.`
+                });
+            } catch (error) {
+                fields.push(fieldName);
+                this.warn(options, {
+                    code: 'fieldValidationFailed',
+                    objectName: group.objectName,
+                    fieldName,
+                    outputPath: group.outputPath,
+                    sequence: group.sequence,
+                    message: `Could not validate field "${fieldName}" on ${group.objectName}: ${getErrorMessage(error)}`
+                });
+            }
+        }
+
+        return { fields: fields.length ? fields : ['Id'], invalidFields };
+    }
+
+    private applyInvalidFieldNulls(records: Record<string, unknown>[], invalidFields: readonly string[]): void {
+        for (const record of records) {
+            for (const field of invalidFields) {
+                setRecordFieldValue(record, field, null);
+            }
+        }
     }
 
     private attachExtractRecords(tree: SourceTree, group: DataMapperExtractGroup, records: Record<string, unknown>[]): void {
@@ -645,6 +776,10 @@ export class DataMapperExecutor {
     private isExtractionItem(item: NormalizedDataMapperItem) {
         return (!!item.inputObjectName || Number(item.inputObjectQuerySequence || 0) > 0) && !item.formulaExpression && item.outputObjectName !== 'Formula';
     }
+
+    private warn(options: Pick<DataMapperExecutionOptions, 'onWarning'>, warning: DataMapperExecutionWarning): void {
+        options.onWarning?.(warning);
+    }
 }
 
 function numberOrUndefined(value: unknown): number | undefined {
@@ -668,6 +803,10 @@ function toRecord(value: unknown): Record<string, unknown> {
 
 function isSpecialFilter(operator: string) {
     return ['LIMIT', 'OFFSET', 'ORDER BY'].includes(operator.toUpperCase());
+}
+
+function isNullOperator(operator: string) {
+    return ['IS NULL', 'IS NOT NULL'].includes(operator.toUpperCase());
 }
 
 function normalizeFilterOperator(operator: string | undefined) {
@@ -765,6 +904,10 @@ function formatSoqlValue(value: unknown): string {
 
 function isQuoted(value: string) {
     return (value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'));
+}
+
+function looksLikeDataMapperReference(value: string) {
+    return value.includes(':') || /\|\d+$|\|n$/i.test(value);
 }
 
 function setPath(target: Record<string, unknown>, path: string, value: unknown, listFormat: boolean): void {

--- a/packages/vlocity/src/datamapper/types.ts
+++ b/packages/vlocity/src/datamapper/types.ts
@@ -126,11 +126,43 @@ export type DataMapperQueryRunner = OmniStudioFormulaQueryRunner;
 
 export type DataMapperFunctionRegistry = OmniStudioFormulaFunctionRegistry;
 
+export type DataMapperExecutionWarningCode =
+    | 'fieldValidationFailed'
+    | 'formulaEvaluationFailed'
+    | 'invalidField'
+    | 'invalidFormula'
+    | 'unresolvedFilter';
+
+export interface DataMapperExecutionWarning {
+    readonly code: DataMapperExecutionWarningCode;
+    readonly message: string;
+    readonly objectName?: string;
+    readonly fieldName?: string;
+    readonly outputPath?: string;
+    readonly sequence?: number;
+    readonly expression?: string;
+}
+
+export interface DataMapperFieldValidationContext {
+    readonly objectName: string;
+    readonly fieldName: string;
+    readonly outputPath: string;
+    readonly sequence: number;
+}
+
+export type DataMapperFieldValidator = (
+    objectName: string,
+    fieldName: string,
+    context: DataMapperFieldValidationContext
+) => boolean | Promise<boolean>;
+
 export interface DataMapperExecutionOptions {
     queryRunner?: DataMapperQueryRunner;
     functionRegistry?: DataMapperFunctionRegistry;
     timezone?: string;
     now?: Date | (() => Date);
+    validateField?: DataMapperFieldValidator;
+    onWarning?: (warning: DataMapperExecutionWarning) => void;
 }
 
 export interface DataMapperFormulaContext extends OmniStudioFormulaContext {

--- a/packages/vscode-extension/src/lib/omnistudio/dataMapperWorkspaceIndex.ts
+++ b/packages/vscode-extension/src/lib/omnistudio/dataMapperWorkspaceIndex.ts
@@ -6,18 +6,34 @@ import { injectable } from '@vlocode/core';
 @injectable()
 export class DataMapperWorkspaceIndex {
     public async names(): Promise<string[]> {
-        const files = await Promise.all([
-            vscode.workspace.findFiles('**/omniDataTransforms/*.rpt-meta.xml', '**/{node_modules,.git}/**'),
-            vscode.workspace.findFiles('**/{DataRaptor,OmniDataTransform}/*/*_DataPack.json', '**/{node_modules,.git}/**')
-        ]);
+        const files = await this.files();
         const names = new Set<string>();
-        for (const uri of files.flat()) {
+        for (const uri of files) {
             const name = this.nameFromPath(uri.fsPath);
             if (name) {
                 names.add(name);
             }
         }
         return [...names].sort((a, b) => a.localeCompare(b));
+    }
+
+    public async uriForName(name: string): Promise<vscode.Uri | undefined> {
+        const candidateNames = new Set(this.referenceNames(name));
+        if (!candidateNames.size) {
+            return undefined;
+        }
+        const matches = (await this.files())
+            .filter(uri => candidateNames.has(this.nameFromPath(uri.fsPath)?.toLowerCase() ?? ''))
+            .sort((a, b) => a.fsPath.localeCompare(b.fsPath));
+        return matches[0];
+    }
+
+    private async files(): Promise<vscode.Uri[]> {
+        const files = await Promise.all([
+            vscode.workspace.findFiles('**/omniDataTransforms/*.rpt-meta.xml', '**/{node_modules,.git}/**'),
+            vscode.workspace.findFiles('**/{DataRaptor,OmniDataTransform}/*/*_DataPack.json', '**/{node_modules,.git}/**')
+        ]);
+        return files.flat();
     }
 
     private nameFromPath(fileName: string): string | undefined {
@@ -32,5 +48,11 @@ export class DataMapperWorkspaceIndex {
 
     private normalizeName(name: string): string {
         return name.replace(/_\d+$/i, '');
+    }
+
+    private referenceNames(name: string): string[] {
+        const normalizedName = this.normalizeName(name.trim());
+        const withoutNamespace = normalizedName.replace(/^%vlocity_namespace%__/i, '').replace(/^[A-Za-z]\w*__(?=.)/, '');
+        return [...new Set([normalizedName, withoutNamespace].filter(Boolean).map(value => value.toLowerCase()))];
     }
 }

--- a/packages/vscode-extension/src/lib/salesforce/apexWorkspaceIndex.ts
+++ b/packages/vscode-extension/src/lib/salesforce/apexWorkspaceIndex.ts
@@ -13,7 +13,7 @@ interface ApexClassDeclaration {
 @injectable()
 export class ApexWorkspaceIndex {
     public async remoteActionClassNames(): Promise<string[]> {
-        const files = await vscode.workspace.findFiles('**/classes/**/*.cls', '**/{node_modules,.git}/**');
+        const files = await this.files();
         const declarations = (await Promise.all(files.map(uri => this.classDeclaration(uri))))
             .filter((declaration): declaration is ApexClassDeclaration => declaration !== undefined);
         const declarationsByName = new Map(declarations.map(declaration => [this.typeName(declaration.name), declaration]));
@@ -21,6 +21,21 @@ export class ApexWorkspaceIndex {
             .filter(declaration => this.isRemoteActionClass(declaration, declarationsByName))
             .map(declaration => declaration.name)
             .sort((a, b) => a.localeCompare(b));
+    }
+
+    public async uriForName(name: string): Promise<vscode.Uri | undefined> {
+        const candidateNames = new Set(this.typeNames(name));
+        if (!candidateNames.size) {
+            return undefined;
+        }
+        const matches = (await this.files())
+            .filter(uri => candidateNames.has(path.basename(uri.fsPath, '.cls').toLowerCase()))
+            .sort((a, b) => a.fsPath.localeCompare(b.fsPath));
+        return matches[0];
+    }
+
+    private async files(): Promise<vscode.Uri[]> {
+        return vscode.workspace.findFiles('**/classes/**/*.cls', '**/{node_modules,.git}/**');
     }
 
     private async classDeclaration(uri: vscode.Uri): Promise<ApexClassDeclaration | undefined> {
@@ -61,6 +76,12 @@ export class ApexWorkspaceIndex {
 
     private typeName(reference: string): string {
         return reference.trim().replace(/\s+/g, '').split('.').pop()?.toLowerCase() ?? '';
+    }
+
+    private typeNames(reference: string): string[] {
+        const name = this.typeName(reference);
+        const withoutNamespace = name.replace(/^[a-z]\w*__(?=.)/, '');
+        return [...new Set([name, withoutNamespace].filter(Boolean))];
     }
 
     private stripComments(source: string): string {

--- a/packages/vscode-extension/src/webviews/dataMapperEditorProvider.ts
+++ b/packages/vscode-extension/src/webviews/dataMapperEditorProvider.ts
@@ -5,7 +5,7 @@ import VlocodeService from '../lib/vlocodeService';
 import { VlocodeCommand } from '../constants';
 import { deepClone, getErrorMessage, isRecord } from '@vlocode/util';
 import { FileSystem, injectable } from '@vlocode/core';
-import { DataMapperExecutor, DatapackInfoService, getDatapackHeaders, VlocityDatapack, type DataMapperDefinition } from '@vlocode/vlocity';
+import { DataMapperExecutor, DatapackInfoService, getDatapackHeaders, VlocityDatapack, type DataMapperDefinition, type DataMapperExecutionWarning } from '@vlocode/vlocity';
 import { MetadataConverter } from '@vlocode/vlocity-deploy';
 import { DatapackExpansionService } from '../lib/vlocity/datapackExpansionService';
 import { VlocodeContext } from '../lib/vlocodeContext';
@@ -67,6 +67,7 @@ interface DataMapperPreviewQuery {
 
 interface DataMapperPreviewDebug {
     queries: DataMapperPreviewQuery[];
+    warnings: DataMapperExecutionWarning[];
     totalDurationMs: number;
 }
 
@@ -125,7 +126,7 @@ export class DataMapperEditorProvider extends ModelBackedEditorProvider<DataMapp
                 return true;
             }
             case 'preview': {
-                const debug: DataMapperPreviewDebug = { queries: [], totalDurationMs: 0 };
+                const debug: DataMapperPreviewDebug = { queries: [], warnings: [], totalDurationMs: 0 };
                 const start = Date.now();
                 try {
                     const output = await this.executePreview(message.model ?? document.data.model, message.input, debug);
@@ -171,6 +172,46 @@ export class DataMapperEditorProvider extends ModelBackedEditorProvider<DataMapp
             ...model.header,
             OmniDataTransformItem: model.items
         };
+        const warningKeys = new Set<string>();
+        const onWarning = (warning: DataMapperExecutionWarning) => {
+            const key = [
+                warning.code,
+                warning.objectName,
+                warning.fieldName,
+                warning.outputPath,
+                warning.sequence,
+                warning.expression,
+                warning.message
+            ].join('\u001f');
+            if (!warningKeys.has(key)) {
+                warningKeys.add(key);
+                debug.warnings.push(warning);
+            }
+        };
+        const fieldValidationCache = new Map<string, Promise<boolean>>();
+        const validateField = (objectName: string, fieldName: string): Promise<boolean> => {
+            if (!this.service.isInitialized) {
+                return Promise.resolve(true);
+            }
+            const cacheKey = `${objectName}\u001f${fieldName}`.toLowerCase();
+            let validation = fieldValidationCache.get(cacheKey);
+            if (!validation) {
+                validation = this.service.salesforceService.schema
+                    .describeSObjectFieldPath(objectName, fieldName, false)
+                    .then(result => !!result)
+                    .catch(error => {
+                        onWarning({
+                            code: 'fieldValidationFailed',
+                            objectName,
+                            fieldName,
+                            message: `Could not validate field "${fieldName}" on ${objectName}: ${getErrorMessage(error)}`
+                        });
+                        return true;
+                    });
+                fieldValidationCache.set(cacheKey, validation);
+            }
+            return validation;
+        };
         const queryRunner = {
             query: async (soql: string): Promise<Record<string, unknown>[]> => {
                 const start = Date.now();
@@ -196,7 +237,7 @@ export class DataMapperEditorProvider extends ModelBackedEditorProvider<DataMapp
                 }
             }
         };
-        return new DataMapperExecutor().execute(definition, input, { queryRunner });
+        return new DataMapperExecutor().execute(definition, input, { queryRunner, validateField, onWarning });
     }
 
     private getDataMapperKind(model: DataMapperModel) {

--- a/packages/vscode-extension/src/webviews/integrationProcedureEditorProvider.ts
+++ b/packages/vscode-extension/src/webviews/integrationProcedureEditorProvider.ts
@@ -185,11 +185,16 @@ export class IntegrationProcedureEditorProvider extends ModelBackedEditorProvide
     }
 
     protected override async handleEditorMessage({ message }: EditorMessageContext<IntegrationProcedureModel, LoadedDocument>): Promise<boolean> {
-        if (message.type !== 'layout') {
-            return false;
+        switch (message.type) {
+            case 'layout':
+                await this.context.globalState.update(LAYOUT_STATE_KEY, this.getLayoutState(message.layout));
+                return true;
+            case 'openReference':
+                await this.openReference(message.kind, message.name);
+                return true;
+            default:
+                return false;
         }
-        await this.context.globalState.update(LAYOUT_STATE_KEY, this.getLayoutState(message.layout));
-        return true;
     }
 
     protected override getDeployCommand(document: LoadedDocument) {
@@ -220,6 +225,30 @@ export class IntegrationProcedureEditorProvider extends ModelBackedEditorProvide
 
     private async openSourceView(uri?: vscode.Uri) {
         await this.openSourceWith('No Integration Procedure file is active.', uri);
+    }
+
+    private async openReference(kind: unknown, name: unknown): Promise<void> {
+        const referenceName = typeof name === 'string' ? name.trim() : '';
+        if (!referenceName) {
+            return;
+        }
+        if (kind === 'dataMapper') {
+            const uri = await this.dataMappers.uriForName(referenceName);
+            if (uri) {
+                await vscode.commands.executeCommand(VlocodeCommand.openDataMapperEditor, uri);
+                return;
+            }
+            void vscode.window.showWarningMessage(`Data Mapper "${referenceName}" was not found in the workspace.`);
+            return;
+        }
+        if (kind === 'apexClass') {
+            const uri = await this.apexClasses.uriForName(referenceName);
+            if (uri) {
+                await vscode.window.showTextDocument(uri, { preview: false });
+                return;
+            }
+            void vscode.window.showWarningMessage(`Apex class "${referenceName}" was not found in the workspace.`);
+        }
     }
 
     protected override async loadDocument(uri: vscode.Uri, text: string): Promise<LoadedDocument> {

--- a/packages/vscode-extension/src/webviews/modelBackedEditorProvider.ts
+++ b/packages/vscode-extension/src/webviews/modelBackedEditorProvider.ts
@@ -252,8 +252,32 @@ export abstract class ModelBackedEditorProvider<
             case 'viewSource':
                 await vscode.commands.executeCommand('vscode.openWith', document.data.uri, 'default', { preview: false });
                 return true;
+            case 'clipboard':
+                await this.handleClipboardMessage(webviewPanel.webview, message);
+                return true;
             default:
                 return false;
+        }
+    }
+
+    private async handleClipboardMessage(webview: vscode.Webview, message: EditorMessage<TModel>): Promise<void> {
+        const requestId = typeof message.requestId === 'string' ? message.requestId : undefined;
+        if (!requestId) {
+            return;
+        }
+        try {
+            if (message.operation === 'read') {
+                webview.postMessage({ type: 'clipboardResponse', requestId, text: await vscode.env.clipboard.readText() });
+                return;
+            }
+            if (message.operation === 'write') {
+                await vscode.env.clipboard.writeText(typeof message.text === 'string' ? message.text : '');
+                webview.postMessage({ type: 'clipboardResponse', requestId });
+                return;
+            }
+            webview.postMessage({ type: 'clipboardResponse', requestId, error: 'Unsupported clipboard operation.' });
+        } catch (error) {
+            webview.postMessage({ type: 'clipboardResponse', requestId, error: getErrorMessage(error) });
         }
     }
 

--- a/packages/vscode-webviews/src/datamapper-editor/app/components/formula-panel/formula-panel.component.html
+++ b/packages/vscode-webviews/src/datamapper-editor/app/components/formula-panel/formula-panel.component.html
@@ -49,12 +49,6 @@
                             (valueChange)="updateFormula(item, 'FormulaResultPath', $event)" />
                     </label>
 
-                    <div class="dm-form-grid">
-                        <label class="dm-field">
-                            <span>Sequence</span>
-                            <input type="number" min="1" [disabled]="item.IsDisabled === true" [ngModel]="item.FormulaSequence || $index + 1" (ngModelChange)="updateFormula(item, 'FormulaSequence', $event)">
-                        </label>
-                    </div>
                 </div>
             </vlo-designer-card>
             <div class="dm-flow__insert">

--- a/packages/vscode-webviews/src/datamapper-editor/app/components/preview-panel/preview-panel.component.html
+++ b/packages/vscode-webviews/src/datamapper-editor/app/components/preview-panel/preview-panel.component.html
@@ -2,7 +2,7 @@
     <header class="dm-preview__top">
         <div>
             <h2>Preview</h2>
-            <p>{{ queryCount() }} queries · {{ resultCount() }} rows · {{ totalDuration() }}</p>
+            <p>{{ queryCount() }} queries · {{ resultCount() }} rows · {{ warningCount() }} warnings · {{ totalDuration() }}</p>
         </div>
         <button type="button" class="dm-button dm-button--primary" [disabled]="running() || !!inputError()" (click)="runPreview.emit()">
             <span class="codicon" [class.codicon-play]="!running()" [class.codicon-loading]="running()" [class.codicon-modifier-spin]="running()" aria-hidden="true"></span>
@@ -43,36 +43,48 @@
             <section class="dm-preview__pane dm-preview__pane--debug" aria-label="Preview query debug">
                 <header class="dm-preview__pane-header">
                     <h3>Debug</h3>
-                    <span>{{ queryCount() }} queries</span>
+                    <span>{{ queryCount() }} queries · {{ warningCount() }} warnings</span>
                 </header>
-                <div class="dm-preview__debug-table-wrap">
-                    <table class="dm-preview__debug-table">
-                        <thead>
-                            <tr>
-                                <th>SOQL</th>
-                                <th>Rows</th>
-                                <th>Time</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @for (query of debug()?.queries ?? []; track $index) {
-                                <tr [class.dm-preview__debug-row--error]="!!query.error">
-                                    <td>
-                                        <code>{{ query.soql }}</code>
-                                        @if (query.error) {
-                                            <small>{{ query.error }}</small>
-                                        }
-                                    </td>
-                                    <td>{{ query.resultCount }}</td>
-                                    <td>{{ formatDuration(query.durationMs) }}</td>
-                                </tr>
-                            } @empty {
-                                <tr>
-                                    <td colspan="3" class="dm-preview__debug-empty">No queries executed.</td>
-                                </tr>
+                <div class="dm-preview__debug-log">
+                    @if ((debug()?.warnings?.length ?? 0) > 0) {
+                        <div class="dm-preview__warnings" aria-label="Preview warnings">
+                            @for (warning of debug()?.warnings ?? []; track $index) {
+                                <div class="dm-preview__warning">
+                                    <span class="codicon codicon-warning" aria-hidden="true"></span>
+                                    <span>{{ warning.message }}</span>
+                                </div>
                             }
-                        </tbody>
-                    </table>
+                        </div>
+                    }
+                    <div class="dm-preview__debug-table-wrap">
+                        <table class="dm-preview__debug-table">
+                            <thead>
+                                <tr>
+                                    <th>SOQL</th>
+                                    <th>Rows</th>
+                                    <th>Time</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (query of debug()?.queries ?? []; track $index) {
+                                    <tr [class.dm-preview__debug-row--error]="!!query.error">
+                                        <td>
+                                            <code>{{ query.soql }}</code>
+                                            @if (query.error) {
+                                                <small>{{ query.error }}</small>
+                                            }
+                                        </td>
+                                        <td>{{ query.resultCount }}</td>
+                                        <td>{{ formatDuration(query.durationMs) }}</td>
+                                    </tr>
+                                } @empty {
+                                    <tr>
+                                        <td colspan="3" class="dm-preview__debug-empty">No queries executed.</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </section>
         </div>

--- a/packages/vscode-webviews/src/datamapper-editor/app/components/preview-panel/preview-panel.component.ts
+++ b/packages/vscode-webviews/src/datamapper-editor/app/components/preview-panel/preview-panel.component.ts
@@ -22,6 +22,7 @@ export class PreviewPanelComponent {
     readonly runPreview = output<void>();
 
     protected readonly queryCount = computed(() => this.debug()?.queries.length ?? 0);
+    protected readonly warningCount = computed(() => this.debug()?.warnings?.length ?? 0);
     protected readonly resultCount = computed(() => this.debug()?.queries.reduce((total, query) => total + query.resultCount, 0) ?? 0);
     protected readonly totalDuration = computed(() => this.formatDuration(this.debug()?.totalDurationMs ?? 0));
 

--- a/packages/vscode-webviews/src/datamapper-editor/app/models/datamapper.model.ts
+++ b/packages/vscode-webviews/src/datamapper-editor/app/models/datamapper.model.ts
@@ -75,8 +75,19 @@ export interface DataMapperPreviewQuery {
     error?: string;
 }
 
+export interface DataMapperPreviewWarning {
+    code: string;
+    message: string;
+    objectName?: string;
+    fieldName?: string;
+    outputPath?: string;
+    sequence?: number;
+    expression?: string;
+}
+
 export interface DataMapperPreviewDebug {
     queries: DataMapperPreviewQuery[];
+    warnings: DataMapperPreviewWarning[];
     totalDurationMs: number;
 }
 

--- a/packages/vscode-webviews/src/datamapper-editor/main.ts
+++ b/packages/vscode-webviews/src/datamapper-editor/main.ts
@@ -6,6 +6,7 @@ import { VlocodeDialogComponent } from '../shared/components/dialog/dialog.compo
 import { VlocodeEditorHeaderComponent } from '../shared/components/editor-header/editor-header.component';
 import { VlocodeEmptyStateComponent } from '../shared/components/empty-state/empty-state.component';
 import { getErrorMessage } from '../shared/utils/object';
+import { registerWebviewApi, type WebviewApi } from '../shared/utils/webview-clipboard';
 import { ExtractPanelComponent } from './app/components/extract-panel/extract-panel.component';
 import { FormulaPanelComponent } from './app/components/formula-panel/formula-panel.component';
 import { LoadObjectsPanelComponent } from './app/components/load-objects-panel/load-objects-panel.component';
@@ -184,6 +185,7 @@ export class AppComponent {
     ]));
 
     constructor() {
+        registerWebviewApi(this.vscode as WebviewApi | undefined);
         window.addEventListener('message', event => this.handleMessage(event.data as ExtensionToWebviewMessage));
         effect(() => this.requestFieldsForCurrentObjects());
         if (this.vscode) {

--- a/packages/vscode-webviews/src/datamapper-editor/styles.scss
+++ b/packages/vscode-webviews/src/datamapper-editor/styles.scss
@@ -11,7 +11,11 @@ body { min-width: 320px; overflow-x: hidden; }
 button, input, select, textarea { font: inherit; }
 
 .dm-shell {
-    width: 100vw; min-height: 100vh; margin-inline: calc(50% - 50vw); background: $editor;
+    width: 100vw; min-height: 100vh; margin-inline: calc(50% - 50vw);
+    background:
+        radial-gradient(circle at 0 0, color-mix(in srgb, #{$panel} 24%, transparent) 1px, transparent 1.5px),
+        color-mix(in srgb, #{$editor} 96%, #{$surface});
+    background-size: 24px 24px, auto;
     &--center { display: grid; place-items: center; padding: 24px; }
 }
 
@@ -65,11 +69,13 @@ button, input, select, textarea { font: inherit; }
 .dm-flow {
     position: relative; width: min(960px, calc(100% - 40px)); margin: 36px auto; padding: 28px 0 60px;
 
-    &::before { content: ""; position: absolute; top: 0; bottom: 0; left: 50%; width: 2px; transform: translateX(-50%); background: $panel-strong; }
+    &::before { content: ""; position: absolute; z-index: 0; top: 0; bottom: 0; left: 50%; width: 2px; transform: translateX(-50%); background: $panel-strong; }
+    > vlo-designer-card { position: relative; z-index: 1; }
     &__start, &__end, &__add {
         position: relative; z-index: 1; display: grid; place-items: center; width: 28px; height: 28px; margin: 0 auto; border-radius: 50%;
     }
     &__start, &__end { border: 4px solid $panel-strong; background: $surface; box-shadow: $shadow-subtle; }
+    &__start { margin-bottom: 24px; }
     &__end { margin-top: 12px; }
     &__insert { position: relative; z-index: 2; display: grid; place-items: center; height: 56px; margin: 0; }
     &__add {
@@ -250,6 +256,19 @@ vlo-monaco-editor,
         }
     }
     &__debug-table-wrap { overflow: auto; min-height: 0; }
+    &__debug-log {
+        display: grid; grid-template-rows: auto minmax(0, 1fr); overflow: hidden; min-height: 0;
+    }
+    &__warnings {
+        display: grid; gap: 6px; max-height: 116px; overflow: auto;
+        padding: 8px 10px; border-bottom: 1px solid $panel;
+        background: color-mix(in srgb, var(--vscode-inputValidation-warningBackground, #{$surface-alt}) 42%, #{$surface});
+    }
+    &__warning {
+        display: grid; grid-template-columns: 16px minmax(0, 1fr); gap: 7px; align-items: start;
+        color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground)); font-size: 12px; line-height: 1.35;
+        .codicon { color: var(--vscode-notificationsWarningIcon-foreground, var(--vscode-editorWarning-foreground)); line-height: 1.35; }
+    }
     &__debug-table {
         width: 100%; border-collapse: collapse; table-layout: fixed;
         th, td { border-bottom: 1px solid $panel; padding: 7px 10px; text-align: left; vertical-align: top; }

--- a/packages/vscode-webviews/src/integration-procedure-editor/app/app.component.html
+++ b/packages/vscode-webviews/src/integration-procedure-editor/app/app.component.html
@@ -123,6 +123,7 @@
                 (elementFieldChange)="updateElementFieldValue($event)"
                 (propertyChange)="updateElementPropertyFromChange($event)"
                 (procedurePropertyChange)="updateProcedurePropertyFromChange($event)"
+                (referenceOpen)="openReference($event)"
                 (mapEntriesChange)="updateMapEntries($event)"
                 (dataRaptorParameterAdd)="addDataRaptorInputParameter()"
                 (dataRaptorParameterChange)="updateDataRaptorInputParameter($event)"

--- a/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-inspector/ip-inspector.component.html
+++ b/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-inspector/ip-inspector.component.html
@@ -65,6 +65,7 @@
                         (headerFieldChange)="headerFieldChange.emit($event)"
                         (elementFieldChange)="elementFieldChange.emit($event)"
                         (propertyChange)="propertyChange.emit($event)"
+                        (referenceOpen)="referenceOpen.emit($event)"
                         (mapEntriesChange)="mapEntriesChange.emit($event)"
                         (dataRaptorParameterAdd)="dataRaptorParameterAdd.emit()"
                         (dataRaptorParameterChange)="dataRaptorParameterChange.emit($event)"

--- a/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-inspector/ip-inspector.component.ts
+++ b/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-inspector/ip-inspector.component.ts
@@ -11,7 +11,8 @@ import type {
     IntegrationProcedureElement,
     IntegrationProcedureModel,
     MapEntriesChange,
-    PropertyValueChange
+    PropertyValueChange,
+    ReferenceOpen
 } from '../../../models/integration-procedure.model';
 import type { monaco } from '../../../../../shared/components/monaco-editor/monaco-editor.component';
 import { IpConditionsTabComponent } from '../ip-conditions-tab/ip-conditions-tab.component';
@@ -62,6 +63,7 @@ export class IpInspectorComponent {
     readonly mapEntriesChange = output<MapEntriesChange>();
     readonly procedurePropertyChange = output<PropertyValueChange>();
     readonly propertyChange = output<PropertyValueChange>();
+    readonly referenceOpen = output<ReferenceOpen>();
     readonly resizeKeydown = output<KeyboardEvent>();
     readonly resizeStart = output<PointerEvent>();
     readonly toggleCollapsed = output<void>();

--- a/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-settings-tab/ip-settings-tab.component.html
+++ b/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-settings-tab/ip-settings-tab.component.html
@@ -12,30 +12,52 @@
         <span>Active</span>
     </label>
     @if (selected.type === 'Remote Action') {
-        <label class="ip-field">
+        <div class="ip-field">
             <span>Remote Class</span>
-            <vlo-autocomplete-input
-                [value]="propertyValue('remoteClass')"
-                [suggestions]="apexClassOptions()"
-                [commitOnInput]="false"
-                ariaLabel="Remote class"
-                (valueChange)="propertyChange.emit({ field: 'remoteClass', value: $event })" />
-        </label>
+            <div class="ip-reference-field">
+                <vlo-autocomplete-input
+                    [value]="propertyValue('remoteClass')"
+                    [suggestions]="apexClassOptions()"
+                    [commitOnInput]="false"
+                    ariaLabel="Remote class"
+                    (valueChange)="propertyChange.emit({ field: 'remoteClass', value: $event })" />
+                <button
+                    type="button"
+                    class="ip-icon-button"
+                    title="Open Apex class"
+                    aria-label="Open Apex class"
+                    [disabled]="!propertyValue('remoteClass').trim()"
+                    (click)="openReference('apexClass', propertyValue('remoteClass'))">
+                    <span class="codicon codicon-link-external" aria-hidden="true"></span>
+                </button>
+            </div>
+        </div>
         <label class="ip-field">
             <span>Remote Method</span>
             <input [value]="propertyValue('remoteMethod')" (input)="propertyChange.emit({ field: 'remoteMethod', value: inputValue($event) })" />
         </label>
         <vlo-key-value-map-editor title="Remote Options" [entries]="entries('remoteOptions')" (entriesChange)="emitMapEntries('remoteOptions', $event)" />
     } @else if (isDataMapperAction(selected.type)) {
-        <label class="ip-field">
+        <div class="ip-field">
             <span>Data Mapper Name</span>
-            <vlo-autocomplete-input
-                [value]="propertyValue('bundle')"
-                [suggestions]="dataMapperOptions()"
-                [commitOnInput]="false"
-                ariaLabel="Data Mapper name"
-                (valueChange)="propertyChange.emit({ field: 'bundle', value: $event })" />
-        </label>
+            <div class="ip-reference-field">
+                <vlo-autocomplete-input
+                    [value]="propertyValue('bundle')"
+                    [suggestions]="dataMapperOptions()"
+                    [commitOnInput]="false"
+                    ariaLabel="Data Mapper name"
+                    (valueChange)="propertyChange.emit({ field: 'bundle', value: $event })" />
+                <button
+                    type="button"
+                    class="ip-icon-button"
+                    title="Open Data Mapper"
+                    aria-label="Open Data Mapper"
+                    [disabled]="!propertyValue('bundle').trim()"
+                    (click)="openReference('dataMapper', propertyValue('bundle'))">
+                    <span class="codicon codicon-link-external" aria-hidden="true"></span>
+                </button>
+            </div>
+        </div>
         <label class="ip-switch">
             <input type="checkbox" [checked]="propertyChecked('ignoreCache')" (change)="propertyChange.emit({ field: 'ignoreCache', value: inputChecked($event) })" />
             <span>Ignore cache</span>

--- a/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-settings-tab/ip-settings-tab.component.ts
+++ b/packages/vscode-webviews/src/integration-procedure-editor/app/components/inspector/ip-settings-tab/ip-settings-tab.component.ts
@@ -13,7 +13,9 @@ import type {
     IntegrationProcedureElement,
     IntegrationProcedureModel,
     MapEntriesChange,
-    PropertyValueChange
+    PropertyValueChange,
+    ReferenceOpen,
+    ReferenceKind
 } from '../../../models/integration-procedure.model';
 import { mapEntries, stringifyValue } from '../../../models/property-set';
 
@@ -39,6 +41,7 @@ export class IpSettingsTabComponent {
     readonly headerFieldChange = output<HeaderFieldChange>();
     readonly mapEntriesChange = output<MapEntriesChange>();
     readonly propertyChange = output<PropertyValueChange>();
+    readonly referenceOpen = output<ReferenceOpen>();
 
     protected readonly inputChecked = inputChecked;
     protected readonly inputValue = inputValue;
@@ -50,6 +53,13 @@ export class IpSettingsTabComponent {
 
     protected emitMapEntries(mapName: string, entries: VlocodeKeyValueEntry[]) {
         this.mapEntriesChange.emit({ mapName, entries });
+    }
+
+    protected openReference(kind: ReferenceKind, name: string) {
+        const trimmedName = name.trim();
+        if (trimmedName) {
+            this.referenceOpen.emit({ kind, name: trimmedName });
+        }
     }
 
     protected propertyChecked(field: string) {

--- a/packages/vscode-webviews/src/integration-procedure-editor/app/models/integration-procedure.model.ts
+++ b/packages/vscode-webviews/src/integration-procedure-editor/app/models/integration-procedure.model.ts
@@ -3,6 +3,7 @@ export type RuntimeShape = 'managed' | 'standard';
 export type LeftTab = 'outline' | 'add' | 'problems';
 export type InspectorTab = 'settings' | 'conditions' | 'io' | 'failure' | 'json';
 export type DropPosition = 'before' | 'after' | 'inside';
+export type ReferenceKind = 'apexClass' | 'dataMapper';
 
 export interface IntegrationProcedureHeader {
     active?: boolean;
@@ -67,6 +68,7 @@ export type WebviewToExtensionMessage =
     | { type: 'refresh' }
     | { type: 'openSalesforce' }
     | { type: 'viewSource' }
+    | { type: 'openReference'; kind: ReferenceKind; name: string }
     | { type: 'layout'; layout: IntegrationProcedureLayout };
 
 export interface FlowRow {
@@ -165,6 +167,11 @@ export interface MapEntriesChange {
 export interface PropertyValueChange {
     field: string;
     value: unknown;
+}
+
+export interface ReferenceOpen {
+    kind: ReferenceKind;
+    name: string;
 }
 
 export const EMPTY_MODEL: IntegrationProcedureModel = {

--- a/packages/vscode-webviews/src/integration-procedure-editor/main.ts
+++ b/packages/vscode-webviews/src/integration-procedure-editor/main.ts
@@ -36,11 +36,13 @@ import {
     type MapEntriesChange,
     type Problem,
     type PropertyValueChange,
+    type ReferenceOpen,
     type WebviewToExtensionMessage
 } from './app/models/integration-procedure.model';
 import { asRecord, dataRaptorInputParameters as getDataRaptorInputParameters, isRecord, setObjectValue, stringifyValue } from './app/models/property-set';
 import { validateModel } from './app/models/validation';
 import { getErrorMessage } from '../shared/utils/object';
+import { registerWebviewApi, type WebviewApi } from '../shared/utils/webview-clipboard';
 
 declare const acquireVsCodeApi: undefined | (() => VsCodeApi);
 
@@ -164,6 +166,7 @@ export class AppComponent {
     protected readonly navigationCollapsed = computed(() => this.layout().leftCollapsed);
 
     constructor() {
+        registerWebviewApi(this.vscode as WebviewApi | undefined);
         const handleWindowMessage = (event: MessageEvent) => this.handleMessage(event.data as ExtensionToWebviewMessage);
         window.addEventListener('message', handleWindowMessage);
         this.destroyRef.onDestroy(() => {
@@ -213,6 +216,14 @@ export class AppComponent {
 
     protected viewSource() {
         this.vscode?.postMessage({ type: 'viewSource' });
+    }
+
+    protected openReference(reference: ReferenceOpen) {
+        this.vscode?.postMessage({
+            type: 'openReference',
+            kind: reference.kind,
+            name: reference.name
+        });
     }
 
     protected toggleNavigationSidebar() {

--- a/packages/vscode-webviews/src/integration-procedure-editor/styles.scss
+++ b/packages/vscode-webviews/src/integration-procedure-editor/styles.scss
@@ -191,6 +191,7 @@ button, input, select, textarea { font: inherit; }
     --ip-rail-collapsed-width: 44px;
     --ip-inspector-current-width: var(--ip-inspector-width, 520px);
     --ip-inspector-collapsed-width: 44px;
+    grid-row: 3;
     min-height: 0;
     display: grid;
     grid-template-columns: var(--ip-rail-current-width) minmax(420px, 1fr) var(--ip-inspector-current-width);
@@ -605,31 +606,10 @@ ip-inspector {
     min-height: 0;
     overflow: auto;
     background:
-        linear-gradient(
-            90deg,
-            color-mix(in srgb, var(--vscode-widget-shadow, black) 14%, transparent) 0,
-            color-mix(in srgb, var(--vscode-widget-shadow, black) 7%, transparent) 12px,
-            transparent 38px,
-            transparent calc(100% - 38px),
-            color-mix(in srgb, var(--vscode-widget-shadow, black) 7%, transparent) calc(100% - 12px),
-            color-mix(in srgb, var(--vscode-widget-shadow, black) 14%, transparent) 100%
-        ),
-        linear-gradient(
-            90deg,
-            transparent 0%,
-            color-mix(in srgb, #{$surface} 7%, transparent) 42%,
-            color-mix(in srgb, #{$surface} 10%, transparent) 50%,
-            color-mix(in srgb, #{$surface} 7%, transparent) 58%,
-            transparent 100%
-        ),
-        linear-gradient(color-mix(in srgb, #{$panel} 13%, transparent) 1px, transparent 1px),
-        linear-gradient(90deg, color-mix(in srgb, #{$panel} 13%, transparent) 1px, transparent 1px),
+        radial-gradient(circle at 0 0, color-mix(in srgb, #{$panel} 24%, transparent) 1px, transparent 1.5px),
         color-mix(in srgb, #{$editor} 96%, #{$surface});
-    background-size: auto, auto, 24px 24px, 24px 24px, auto;
-    box-shadow:
-        inset 0 1px 0 color-mix(in srgb, var(--vscode-foreground) 3%, transparent),
-        inset 30px 0 32px -26px color-mix(in srgb, var(--vscode-widget-shadow, black) 36%, transparent),
-        inset -30px 0 32px -26px color-mix(in srgb, var(--vscode-widget-shadow, black) 36%, transparent);
+    background-size: 24px 24px, auto;
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--vscode-foreground) 3%, transparent);
 }
 
 body.vscode-high-contrast .ip-rail,
@@ -648,10 +628,9 @@ body.vscode-high-contrast-light .ip-canvas,
 body[data-vscode-theme-kind='vscode-high-contrast'] .ip-canvas,
 body[data-vscode-theme-kind='vscode-high-contrast-light'] .ip-canvas {
     background:
-        linear-gradient(color-mix(in srgb, #{$panel} 18%, transparent) 1px, transparent 1px),
-        linear-gradient(90deg, color-mix(in srgb, #{$panel} 18%, transparent) 1px, transparent 1px),
+        radial-gradient(circle at 0 0, color-mix(in srgb, #{$panel} 42%, transparent) 1px, transparent 1.5px),
         $editor;
-    background-size: 24px 24px, 24px 24px, auto;
+    background-size: 24px 24px, auto;
     box-shadow: none;
 }
 

--- a/packages/vscode-webviews/src/integration-procedure-editor/styles.scss
+++ b/packages/vscode-webviews/src/integration-procedure-editor/styles.scss
@@ -1343,6 +1343,25 @@ body[data-vscode-theme-kind='vscode-high-contrast-light'] .ip-canvas {
     @include control;
 }
 
+.ip-reference-field {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 30px;
+    align-items: stretch;
+    gap: 6px;
+    min-width: 0;
+
+    vlo-autocomplete-input {
+        display: block;
+        min-width: 0;
+    }
+
+    .ip-icon-button {
+        width: 30px;
+        height: 30px;
+        flex-basis: 30px;
+    }
+}
+
 .ip-readonly-value {
     min-height: 30px;
     border: 1px solid color-mix(in srgb, #{$panel} 78%, transparent);

--- a/packages/vscode-webviews/src/shared/components/designer-card/designer-card.component.html
+++ b/packages/vscode-webviews/src/shared/components/designer-card/designer-card.component.html
@@ -12,8 +12,8 @@
     (dragover)="cardDragOver.emit($event)"
     (drop)="cardDrop.emit($event)"
     (dragend)="cardDragEnd.emit($event)">
-    <header class="vlo-designer-card__header">
-        <button type="button" class="vlo-designer-card__toggle" [attr.aria-expanded]="expanded()" [attr.aria-label]="toggleLabel()" (click)="toggleExpanded()">
+    <header class="vlo-designer-card__header" [attr.aria-label]="toggleLabel()" (click)="toggleExpandedFromHeader($event)">
+        <button type="button" class="vlo-designer-card__toggle" [attr.aria-expanded]="expanded()" [attr.aria-label]="toggleLabel()" (click)="toggleExpanded($event)">
             <span class="codicon" [class.codicon-chevron-down]="expanded()" [class.codicon-chevron-right]="!expanded()" aria-hidden="true"></span>
         </button>
         <span [ngClass]="['vlo-designer-card__icon', 'codicon', 'codicon-' + icon()]" aria-hidden="true"></span>

--- a/packages/vscode-webviews/src/shared/components/designer-card/designer-card.component.ts
+++ b/packages/vscode-webviews/src/shared/components/designer-card/designer-card.component.ts
@@ -29,11 +29,23 @@ export class VlocodeDesignerCardComponent {
 
     protected readonly expanded = signal(false);
 
-    protected toggleExpanded() {
+    protected toggleExpanded(event?: MouseEvent) {
+        event?.stopPropagation();
         this.expanded.update(expanded => !expanded);
+    }
+
+    protected toggleExpandedFromHeader(event: MouseEvent) {
+        if (this.isInteractiveHeaderTarget(event.target)) {
+            return;
+        }
+        this.toggleExpanded(event);
     }
 
     protected toggleLabel() {
         return `${this.expanded() ? 'Collapse' : 'Expand'} ${this.toggleName()}`;
+    }
+
+    private isInteractiveHeaderTarget(target: EventTarget | null) {
+        return target instanceof Element && !!target.closest('.vlo-designer-card__actions, button, a, input, select, textarea, [role="button"]');
     }
 }

--- a/packages/vscode-webviews/src/shared/components/formula-input/formula-input.component.ts
+++ b/packages/vscode-webviews/src/shared/components/formula-input/formula-input.component.ts
@@ -1,0 +1,84 @@
+import { ChangeDetectionStrategy, Component, input, output, signal } from '@angular/core';
+
+import { inputValue } from '../../utils/dom-events';
+import { VlocodeDialogComponent } from '../dialog/dialog.component';
+import { VlocodeFormulaEditorComponent } from '../formula-editor/formula-editor.component';
+
+@Component({
+    selector: 'vlo-formula-input',
+    standalone: true,
+    imports: [VlocodeDialogComponent, VlocodeFormulaEditorComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+        <span class="vlocode-formula-input" [class.vlocode-formula-input--with-button]="formulaEnabled()">
+            <input
+                class="vlocode-formula-input__control"
+                [attr.aria-label]="ariaLabel()"
+                [value]="value()"
+                (input)="valueChange.emit(inputValue($event))" />
+            @if (formulaEnabled()) {
+                <button
+                    type="button"
+                    class="vlocode-formula-input__button"
+                    [title]="buttonTitle()"
+                    [attr.aria-label]="buttonAriaLabel()"
+                    (click)="openFormulaEditor()">fx</button>
+            }
+        </span>
+
+        @if (editorOpen()) {
+            <vlo-dialog
+                type="info"
+                icon="symbol-method"
+                size="wide"
+                confirmIcon="check"
+                [title]="dialogTitle()"
+                [message]="dialogMessage()"
+                [confirmLabel]="confirmLabel()"
+                (cancel)="closeFormulaEditor()"
+                (confirm)="applyFormulaEditor()">
+                <div class="vlocode-formula-input__dialog-body">
+                    <div class="vlocode-field vlocode-formula-input__formula">
+                        <span>{{ valueLabel() }}</span>
+                        <vlo-formula-editor
+                            [value]="draftValue()"
+                            [ariaLabel]="editorAriaLabel()"
+                            (valueChange)="draftValue.set($event)" />
+                    </div>
+                </div>
+            </vlo-dialog>
+        }
+    `
+})
+export class VlocodeFormulaInputComponent {
+    readonly ariaLabel = input('Formula value');
+    readonly buttonAriaLabel = input('Open formula editor');
+    readonly buttonTitle = input('Open formula editor');
+    readonly confirmLabel = input('Apply');
+    readonly dialogMessage = input('');
+    readonly dialogTitle = input('Formula Editor');
+    readonly editorAriaLabel = input('Formula editor');
+    readonly formulaEnabled = input(true);
+    readonly value = input('');
+    readonly valueLabel = input('Value');
+
+    readonly valueChange = output<string>();
+
+    protected readonly draftValue = signal('');
+    protected readonly editorOpen = signal(false);
+    protected readonly inputValue = inputValue;
+
+    protected openFormulaEditor() {
+        this.draftValue.set(this.value());
+        this.editorOpen.set(true);
+    }
+
+    protected closeFormulaEditor() {
+        this.editorOpen.set(false);
+    }
+
+    protected applyFormulaEditor() {
+        this.valueChange.emit(this.draftValue());
+        this.closeFormulaEditor();
+    }
+}

--- a/packages/vscode-webviews/src/shared/components/key-value-map-editor/key-value-map-editor.component.html
+++ b/packages/vscode-webviews/src/shared/components/key-value-map-editor/key-value-map-editor.component.html
@@ -10,12 +10,14 @@
         @for (entry of entries(); track $index) {
             <div class="vlocode-map-editor__row">
                 <input aria-label="Key" [value]="entry.key" (input)="updateEntry($index, 'key', $event)" />
-                <span class="vlocode-map-editor__value">
-                    <input aria-label="Value" [value]="entry.value" (input)="updateEntry($index, 'value', $event)" />
-                    @if (formulaEnabled()) {
-                        <button type="button" class="vlocode-map-editor__formula-button" title="Open formula editor" aria-label="Open formula editor for {{ entry.key }}" (click)="openFormulaEditor(entry, $index)">fx</button>
-                    }
-                </span>
+                <vlo-formula-input
+                    [value]="entry.value"
+                    [formulaEnabled]="formulaEnabled()"
+                    [buttonAriaLabel]="'Open formula editor for ' + (entry.key || 'value')"
+                    [dialogMessage]="entry.key || title()"
+                    ariaLabel="Value"
+                    editorAriaLabel="Map entry value formula"
+                    (valueChange)="updateEntryValue($index, $event)" />
                 <button type="button" class="vlocode-icon-button vlocode-icon-button--danger" title="Delete row" (click)="deleteEntry($index)">
                     <span class="codicon codicon-trash" aria-hidden="true"></span>
                 </button>
@@ -25,32 +27,3 @@
         <p class="vlocode-muted">{{ emptyMessage() }}</p>
     }
 </section>
-
-@if (formulaEditor(); as editor) {
-    <vlo-dialog
-        type="info"
-        icon="symbol-method"
-        confirmIcon="check"
-        title="Formula Editor"
-        [message]="title()"
-        confirmLabel="Apply"
-        (cancel)="closeFormulaEditor()"
-        (confirm)="applyFormulaEditor()">
-        <div class="vlocode-map-editor__dialog-body">
-            <label class="vlocode-field">
-                <span>Key</span>
-                <input [value]="editor.entry.key" (input)="updateFormulaEditorKey($event)" />
-            </label>
-            <div class="vlocode-field vlocode-map-editor__formula">
-                <span>Value</span>
-                <vlo-formula-editor
-                    [value]="editor.entry.value"
-                    ariaLabel="Map entry value formula"
-                    (valueChange)="updateFormulaEditorValue($event)" />
-            </div>
-            @if (formulaError(); as error) {
-                <div class="vlocode-inline-error">{{ error }}</div>
-            }
-        </div>
-    </vlo-dialog>
-}

--- a/packages/vscode-webviews/src/shared/components/key-value-map-editor/key-value-map-editor.component.ts
+++ b/packages/vscode-webviews/src/shared/components/key-value-map-editor/key-value-map-editor.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 
-import { VlocodeDialogComponent } from '../dialog/dialog.component';
-import { VlocodeFormulaEditorComponent } from '../formula-editor/formula-editor.component';
+import { VlocodeFormulaInputComponent } from '../formula-input/formula-input.component';
 import { inputValue } from '../../utils/dom-events';
 
 export interface VlocodeKeyValueEntry {
@@ -9,15 +8,10 @@ export interface VlocodeKeyValueEntry {
     value: string;
 }
 
-interface FormulaEditorState {
-    entry: VlocodeKeyValueEntry;
-    index: number;
-}
-
 @Component({
     selector: 'vlo-key-value-map-editor',
     standalone: true,
-    imports: [VlocodeFormulaEditorComponent, VlocodeDialogComponent],
+    imports: [VlocodeFormulaInputComponent],
     changeDetection: ChangeDetectionStrategy.OnPush,
     templateUrl: './key-value-map-editor.component.html'
 })
@@ -29,8 +23,6 @@ export class VlocodeKeyValueMapEditorComponent {
 
     readonly entriesChange = output<VlocodeKeyValueEntry[]>();
 
-    protected readonly formulaEditor = signal<FormulaEditorState | undefined>(undefined);
-    protected readonly formulaError = signal<string | undefined>(undefined);
     protected readonly inputValue = inputValue;
     protected readonly keys = computed(() => new Set(this.entries().map(entry => entry.key)));
 
@@ -47,58 +39,20 @@ export class VlocodeKeyValueMapEditorComponent {
 
     protected updateEntry(index: number, part: keyof VlocodeKeyValueEntry, event: Event) {
         const value = this.inputValue(event);
+        this.patchEntry(index, { [part]: value });
+    }
+
+    protected updateEntryValue(index: number, value: string) {
+        this.patchEntry(index, { value });
+    }
+
+    private patchEntry(index: number, patch: Partial<VlocodeKeyValueEntry>) {
         this.entriesChange.emit(this.entries().map((entry, entryIndex) =>
-            entryIndex === index ? { ...entry, [part]: value } : entry
+            entryIndex === index ? { ...entry, ...patch } : entry
         ));
     }
 
     protected deleteEntry(index: number) {
         this.entriesChange.emit(this.entries().filter((_entry, entryIndex) => entryIndex !== index));
-    }
-
-    protected openFormulaEditor(entry: VlocodeKeyValueEntry, index: number) {
-        this.formulaEditor.set({ entry: { ...entry }, index });
-        this.formulaError.set(undefined);
-    }
-
-    protected closeFormulaEditor() {
-        this.formulaEditor.set(undefined);
-        this.formulaError.set(undefined);
-    }
-
-    protected updateFormulaEditorKey(event: Event) {
-        this.patchFormulaEditor({ key: this.inputValue(event) });
-    }
-
-    protected updateFormulaEditorValue(value: string) {
-        this.patchFormulaEditor({ value });
-    }
-
-    protected applyFormulaEditor() {
-        const editor = this.formulaEditor();
-        if (!editor) {
-            return;
-        }
-        const key = editor.entry.key.trim();
-        if (!key) {
-            this.formulaError.set('Key is required.');
-            return;
-        }
-        if (this.entries().some((entry, index) => index !== editor.index && entry.key === key)) {
-            this.formulaError.set(`"${key}" already exists.`);
-            return;
-        }
-        this.entriesChange.emit(this.entries().map((entry, index) =>
-            index === editor.index ? { key, value: editor.entry.value } : entry
-        ));
-        this.closeFormulaEditor();
-    }
-
-    private patchFormulaEditor(patch: Partial<VlocodeKeyValueEntry>) {
-        const editor = this.formulaEditor();
-        if (editor) {
-            this.formulaEditor.set({ ...editor, entry: { ...editor.entry, ...patch } });
-            this.formulaError.set(undefined);
-        }
     }
 }

--- a/packages/vscode-webviews/src/shared/components/monaco-editor/monaco-editor.component.ts
+++ b/packages/vscode-webviews/src/shared/components/monaco-editor/monaco-editor.component.ts
@@ -211,20 +211,24 @@ export class VlocodeMonacoEditorComponent implements AfterViewInit {
 
     private async copySelection(editor: monaco.editor.IStandaloneCodeEditor, event: monaco.IKeyboardEvent, cut: boolean) {
         const model = editor.getModel();
-        const selections = editor.getSelections()?.filter(selection => !selection.isEmpty()) ?? [];
+        const selections = editor.getSelections() ?? [];
         if (!model || selections.length === 0) {
             return;
         }
+        const hasSelection = selections.some(selection => !selection.isEmpty());
+        const ranges = hasSelection
+            ? selections.filter(selection => !selection.isEmpty())
+            : getFullLineRanges(model, selections);
 
         event.preventDefault();
         event.stopPropagation();
 
-        await writeClipboardText(selections.map(selection => model.getValueInRange(selection)).join('\n'));
+        await writeClipboardText(ranges.map(range => model.getValueInRange(range)).join(hasSelection ? '\n' : ''));
         if (!cut || this.readOnly()) {
             return;
         }
 
-        editor.executeEdits('clipboard', selections.map(selection => ({ range: selection, text: '' })));
+        editor.executeEdits('clipboard', ranges.map(range => ({ range, text: '' })));
     }
 
     private async pasteClipboardText(editor: monaco.editor.IStandaloneCodeEditor, event: monaco.IKeyboardEvent) {
@@ -244,6 +248,32 @@ export class VlocodeMonacoEditorComponent implements AfterViewInit {
 
 function usesPrimaryModifier(event: monaco.IKeyboardEvent) {
     return event.metaKey || event.ctrlKey;
+}
+
+function getFullLineRanges(model: monaco.editor.ITextModel, selections: readonly monaco.Selection[]) {
+    const lineNumbers = [...new Set(selections.map(selection => selection.positionLineNumber))]
+        .sort((left, right) => left - right);
+    const ranges = new Array<monaco.Range>();
+    let blockStart = lineNumbers[0];
+    let blockEnd = lineNumbers[0];
+    for (const lineNumber of lineNumbers.slice(1)) {
+        if (lineNumber === blockEnd + 1) {
+            blockEnd = lineNumber;
+        } else {
+            ranges.push(getFullLineRange(model, blockStart, blockEnd));
+            blockStart = lineNumber;
+            blockEnd = lineNumber;
+        }
+    }
+    ranges.push(getFullLineRange(model, blockStart, blockEnd));
+    return ranges;
+}
+
+function getFullLineRange(model: monaco.editor.ITextModel, startLine: number, endLine: number) {
+    if (endLine < model.getLineCount()) {
+        return new monaco.Range(startLine, 1, endLine + 1, 1);
+    }
+    return new monaco.Range(startLine, 1, endLine, model.getLineMaxColumn(endLine));
 }
 
 export { monaco };

--- a/packages/vscode-webviews/src/shared/components/monaco-editor/monaco-editor.component.ts
+++ b/packages/vscode-webviews/src/shared/components/monaco-editor/monaco-editor.component.ts
@@ -8,6 +8,8 @@ import 'monaco-editor/esm/vs/editor/contrib/parameterHints/browser/parameterHint
 import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController.js';
 import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
 
+import { readClipboardText, writeClipboardText } from '../../utils/webview-clipboard';
+
 type MonacoGlobal = typeof globalThis & {
     MonacoEnvironment?: monaco.Environment;
 };
@@ -169,14 +171,19 @@ export class VlocodeMonacoEditorComponent implements AfterViewInit {
         this.themeObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
         this.themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
-        this.editor.onDidChangeModelContent(() => {
+        const contentDisposable = this.editor.onDidChangeModelContent(() => {
             if (!this.readOnly() && !this.applyingExternalValue) {
                 this.valueChange.emit(this.editor?.getValue() ?? '');
             }
         });
+        const keyDisposable = this.editor.onKeyDown(event => {
+            void this.handleClipboardShortcut(event).catch(() => undefined);
+        });
 
         this.editorReady.emit(this.editor);
         this.destroyRef.onDestroy(() => {
+            contentDisposable.dispose();
+            keyDisposable.dispose();
             const model = this.editor?.getModel();
             if (model) {
                 monaco.editor.setModelMarkers(model, this.markerOwner(), []);
@@ -187,6 +194,56 @@ export class VlocodeMonacoEditorComponent implements AfterViewInit {
             this.themeObserver = undefined;
         });
     }
+
+    private async handleClipboardShortcut(event: monaco.IKeyboardEvent) {
+        const editor = this.editor;
+        if (!editor || !usesPrimaryModifier(event) || event.altKey) {
+            return;
+        }
+
+        const key = event.browserEvent.key.toLowerCase();
+        if (key === 'c' || key === 'x') {
+            await this.copySelection(editor, event, key === 'x');
+        } else if (key === 'v') {
+            await this.pasteClipboardText(editor, event);
+        }
+    }
+
+    private async copySelection(editor: monaco.editor.IStandaloneCodeEditor, event: monaco.IKeyboardEvent, cut: boolean) {
+        const model = editor.getModel();
+        const selections = editor.getSelections()?.filter(selection => !selection.isEmpty()) ?? [];
+        if (!model || selections.length === 0) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        await writeClipboardText(selections.map(selection => model.getValueInRange(selection)).join('\n'));
+        if (!cut || this.readOnly()) {
+            return;
+        }
+
+        editor.executeEdits('clipboard', selections.map(selection => ({ range: selection, text: '' })));
+    }
+
+    private async pasteClipboardText(editor: monaco.editor.IStandaloneCodeEditor, event: monaco.IKeyboardEvent) {
+        if (this.readOnly()) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const text = await readClipboardText();
+        if (text) {
+            editor.trigger('keyboard', 'paste', { text });
+        }
+    }
+}
+
+function usesPrimaryModifier(event: monaco.IKeyboardEvent) {
+    return event.metaKey || event.ctrlKey;
 }
 
 export { monaco };

--- a/packages/vscode-webviews/src/shared/styles/_webview.scss
+++ b/packages/vscode-webviews/src/shared/styles/_webview.scss
@@ -431,6 +431,15 @@ vlo-designer-card {
     }
 }
 
+vlo-key-value-map-editor {
+    display: block;
+    min-width: 0;
+
+    + vlo-key-value-map-editor {
+        margin-top: 18px;
+    }
+}
+
 .vlocode-map-editor {
     display: grid;
     gap: 10px;
@@ -457,23 +466,32 @@ vlo-designer-card {
         align-items: end;
         gap: 10px;
 
-        > input,
-        .vlocode-map-editor__value > input {
+        > input {
             @include control;
         }
     }
+}
 
-    &__value {
-        display: grid;
+.vlocode-formula-input {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    min-width: 0;
+
+    &--with-button {
         grid-template-columns: minmax(0, 1fr) 32px;
+    }
+
+    &__control {
+        @include control;
         min-width: 0;
     }
 
-    &__value > input {
+    &--with-button &__control {
+        border-right-color: transparent;
         border-radius: $radius-control 0 0 $radius-control;
     }
 
-    &__formula-button {
+    &__button {
         @include button;
         display: inline-grid;
         place-items: center;
@@ -490,10 +508,21 @@ vlo-designer-card {
     &__dialog-body {
         display: grid;
         gap: 12px;
-        min-width: min(720px, calc(100vw - 96px));
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+
+        .vlocode-field {
+            min-width: 0;
+
+            > input {
+                min-width: 0;
+            }
+        }
     }
 
     &__formula {
+        min-width: 0;
         height: min(300px, calc(100vh - 320px));
         min-height: 180px;
 

--- a/packages/vscode-webviews/src/shared/styles/_webview.scss
+++ b/packages/vscode-webviews/src/shared/styles/_webview.scss
@@ -319,14 +319,14 @@ vlo-designer-card {
         border-bottom: 1px solid $panel;
         border-radius: $radius-surface $radius-surface 0 0;
         background: $surface-alt;
-        cursor: grab;
+        cursor: pointer;
 
         > div {
             min-width: 0;
         }
 
         &:active {
-            cursor: grabbing;
+            cursor: pointer;
         }
     }
 
@@ -385,16 +385,30 @@ vlo-designer-card {
     }
 
     &__icon {
-        flex: 0 0 auto;
+        display: inline-grid;
+        place-items: center;
+        flex: 0 0 40px;
         width: 40px;
         height: 40px;
         border-radius: $radius-surface;
         color: var(--vscode-button-foreground);
         font-size: 22px;
+        line-height: 1;
         background: var(--vscode-button-background);
 
         &.codicon[class*='codicon-'] {
-            @include centered-codicon(22px);
+            display: inline-grid;
+            place-items: center;
+            width: 40px;
+            height: 40px;
+            font-size: 22px;
+            line-height: 1;
+
+            &::before {
+                display: block;
+                font-size: 22px;
+                line-height: 1;
+            }
         }
     }
 

--- a/packages/vscode-webviews/src/shared/utils/webview-clipboard.ts
+++ b/packages/vscode-webviews/src/shared/utils/webview-clipboard.ts
@@ -1,0 +1,96 @@
+export interface WebviewApi {
+    postMessage(message: unknown): void;
+}
+
+type ClipboardOperation = 'read' | 'write';
+
+interface ClipboardResponse {
+    error?: string;
+    requestId: string;
+    text?: string;
+    type: 'clipboardResponse';
+}
+
+interface PendingRequest {
+    reject(error: Error): void;
+    resolve(text: string): void;
+    timeout: number;
+}
+
+let vscodeApi: WebviewApi | undefined;
+let nextRequestId = 0;
+let listening = false;
+const pending = new Map<string, PendingRequest>();
+
+export function registerWebviewApi(api: WebviewApi | undefined) {
+    vscodeApi = api;
+    if (!listening) {
+        listening = true;
+        window.addEventListener('message', event => handleClipboardResponse(event.data));
+    }
+}
+
+export async function readClipboardText(): Promise<string> {
+    return requestClipboard('read');
+}
+
+export async function writeClipboardText(text: string): Promise<void> {
+    await requestClipboard('write', text);
+}
+
+async function requestClipboard(operation: 'read'): Promise<string>;
+async function requestClipboard(operation: 'write', text: string): Promise<string>;
+async function requestClipboard(operation: ClipboardOperation, text = ''): Promise<string> {
+    if (vscodeApi) {
+        return requestVsCodeClipboard(operation, text);
+    }
+    return requestBrowserClipboard(operation, text);
+}
+
+function requestVsCodeClipboard(operation: ClipboardOperation, text: string): Promise<string> {
+    const requestId = `clipboard-${Date.now()}-${++nextRequestId}`;
+    return new Promise((resolve, reject) => {
+        const timeout = window.setTimeout(() => {
+            pending.delete(requestId);
+            reject(new Error('Timed out waiting for VS Code clipboard response.'));
+        }, 3000);
+        pending.set(requestId, { reject, resolve, timeout });
+        vscodeApi?.postMessage({ type: 'clipboard', requestId, operation, text });
+    });
+}
+
+async function requestBrowserClipboard(operation: ClipboardOperation, text: string): Promise<string> {
+    if (!navigator.clipboard) {
+        throw new Error('Clipboard API is not available.');
+    }
+    if (operation === 'read') {
+        return navigator.clipboard.readText();
+    }
+    await navigator.clipboard.writeText(text);
+    return '';
+}
+
+function handleClipboardResponse(message: unknown) {
+    if (!isClipboardResponse(message)) {
+        return;
+    }
+    const request = pending.get(message.requestId);
+    if (!request) {
+        return;
+    }
+    pending.delete(message.requestId);
+    window.clearTimeout(request.timeout);
+    if (message.error) {
+        request.reject(new Error(message.error));
+    } else {
+        request.resolve(message.text ?? '');
+    }
+}
+
+function isClipboardResponse(message: unknown): message is ClipboardResponse {
+    if (!message || typeof message !== 'object') {
+        return false;
+    }
+    const candidate = message as Partial<ClipboardResponse>;
+    return candidate.type === 'clipboardResponse' && typeof candidate.requestId === 'string';
+}


### PR DESCRIPTION
Summary:
- Fix DataMapper preview handling for unresolved refs, invalid fields, and formula warnings.
- Restore Monaco clipboard behavior and reusable formula inputs in webviews.
- Polish DM/IP editor layout and add open referenced mapper/class buttons.
- Create .sfdx/sfdx-config.json when org switching has no local SFDX config.

Validation:
- pnpm build
- pnpm jest packages/util/src/__tests__/sfdx.test.ts -i --coverage=false