### PR TITLE
feat: make production deploy test level configurable

### DIFF
--- a/packages/salesforce/src/connection/metadata/types/deployResult.ts
+++ b/packages/salesforce/src/connection/metadata/types/deployResult.ts
@@ -268,7 +268,7 @@ export interface DeployOptions {
      * 
      * _Note: Apex tests that run as part of a deployment always run synchronously and serially._
      */
-    testLevel?: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg';
+    testLevel?: 'NoTestRun' | 'RunRelevantTests' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg';
     /**
      * Indicates whether the specified .zip file points to a directory 
      * structure with a single package (`true`) or a set of packages (`false`).

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1513,6 +1513,21 @@
                         "default": false,
                         "markdownDescription": "Automatically deploy metadata files to Salesforce when saved."
                     },
+                    "vlocity.salesforce.productionDeployTestLevel": {
+                        "type": "string",
+                        "enum": [
+                            "RunRelevantTests",
+                            "RunLocalTests",
+                            "RunAllTestsInOrg"
+                        ],
+                        "default": "RunRelevantTests",
+                        "enumDescriptions": [
+                            "Run tests that Salesforce determines are relevant to the deployed metadata.",
+                            "Run all local Apex tests in the production org.",
+                            "Run all Apex tests in the production org, including managed package tests."
+                        ],
+                        "markdownDescription": "Apex test level used for Salesforce metadata deployments to production orgs. `NoTestRun` is not available in production."
+                    },
                     "vlocity.salesforce.profileActionsInContextMenu": {
                         "type": "boolean",
                         "default": true,

--- a/packages/vscode-extension/src/commands/metadata/__tests__/deployMetadataCommand.test.ts
+++ b/packages/vscode-extension/src/commands/metadata/__tests__/deployMetadataCommand.test.ts
@@ -1,0 +1,56 @@
+import DeployMetadataCommand from '../deployMetadataCommand';
+
+class TestDeployMetadataCommand extends DeployMetadataCommand {
+
+    public execute() {
+        return undefined;
+    }
+
+    constructor(
+        private readonly productionOrg: boolean,
+        productionDeployTestLevel?: string
+    ) {
+        super();
+        Object.defineProperty(this, 'vlocode', {
+            value: {
+                config: {
+                    salesforce: {
+                        productionDeployTestLevel
+                    }
+                }
+            }
+        });
+    }
+
+    protected get salesforce() {
+        return {
+            isProductionOrg: async () => this.productionOrg
+        } as any;
+    }
+
+    public getOptions() {
+        return this.getDeploymentStartOptions();
+    }
+}
+
+describe('DeployMetadataCommand', () => {
+    it('defaults production deployments to RunRelevantTests', async () => {
+        await expect(new TestDeployMetadataCommand(true).getOptions()).resolves.toEqual({
+            ignoreWarnings: true,
+            testLevel: 'RunRelevantTests'
+        });
+    });
+
+    it('uses the configured production deployment test level', async () => {
+        await expect(new TestDeployMetadataCommand(true, 'RunLocalTests').getOptions()).resolves.toEqual({
+            ignoreWarnings: true,
+            testLevel: 'RunLocalTests'
+        });
+    });
+
+    it('does not set a test level for non-production deployments', async () => {
+        await expect(new TestDeployMetadataCommand(false, 'RunLocalTests').getOptions()).resolves.toEqual({
+            ignoreWarnings: true
+        });
+    });
+});

--- a/packages/vscode-extension/src/commands/metadata/deployMetadataCommand.ts
+++ b/packages/vscode-extension/src/commands/metadata/deployMetadataCommand.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import open from 'open';
 
-import { DeployResult, RetrieveDeltaStrategy, SalesforceDeployment, SalesforcePackage, SalesforcePackageBuilder, SalesforcePackageType } from '@vlocode/salesforce';
+import { DeployOptions, DeployResult, RetrieveDeltaStrategy, SalesforceDeployment, SalesforcePackage, SalesforcePackageBuilder, SalesforcePackageType } from '@vlocode/salesforce';
 
 import { VlocodeCommand } from '../../constants';
 import { ActivityProgress } from '../../lib/vlocodeActivity';
@@ -196,7 +196,7 @@ export default class DeployMetadataCommand extends MetadataCommand {
             deployment.cancel();
         });
 
-        await deployment.start({ ignoreWarnings: true });
+        await deployment.start(await this.getDeploymentStartOptions());
         this.logger.info(`Deployment details: ${await this.vlocode.salesforceService.getPageUrl(deployment.setupUrl)}`);
         const result = await deployment.getResult();
 
@@ -206,6 +206,14 @@ export default class DeployMetadataCommand extends MetadataCommand {
 
         this.outputDeployResult(result);
         return this.onDeploymentComplete(deployment, result);
+    }
+
+    protected async getDeploymentStartOptions(): Promise<DeployOptions> {
+        const options: DeployOptions = { ignoreWarnings: true };
+        if (await this.salesforce.isProductionOrg()) {
+            options.testLevel = this.vlocode.config.salesforce.productionDeployTestLevel ?? 'RunRelevantTests';
+        }
+        return options;
     }
 
     private onDeploymentComplete(deployment: SalesforceDeployment, result: DeployResult) {

--- a/packages/vscode-extension/src/lib/vlocodeConfiguration.ts
+++ b/packages/vscode-extension/src/lib/vlocodeConfiguration.ts
@@ -4,6 +4,7 @@ export abstract class VlocodeSalesforceConfiguration extends BaseConfiguration {
     enabled: boolean;
     deployOnSave: boolean;
     apiVersion: string;
+    productionDeployTestLevel: 'RunRelevantTests' | 'RunLocalTests' | 'RunAllTestsInOrg';
     manageMetaXmlFiles: boolean;
     developerLogsVisible: boolean;
     developerLogsAutoRefresh: boolean;


### PR DESCRIPTION
- Add `vlocity.salesforce.productionDeployTestLevel` with `RunRelevantTests` as the default production metadata deploy level.
- Apply the configured test level only for production metadata deployments, preserving non-production no-test behavior.
- Extend deploy option typing and cover production/non-production option selection with focused tests.

Validation:
- `pnpm build`
- `pnpm jest packages/vscode-extension/src/commands/metadata/__tests__/deployMetadataCommand.test.ts -i --coverage=false`
- `pnpm exec eslint packages/vscode-extension/src/commands/metadata/deployMetadataCommand.ts packages/vscode-extension/src/commands/metadata/__tests__/deployMetadataCommand.test.ts packages/vscode-extension/src/lib/vlocodeConfiguration.ts packages/salesforce/src/connection/metadata/types/deployResult.ts --no-error-on-unmatched-pattern`
- `git diff --check`