### PR TITLE
feat: add embedded-aware datapack compare

### DIFF
--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -1,0 +1,147 @@
+import { existsSync } from 'fs';
+import { mkdir, stat, writeFile } from 'fs/promises';
+import { dirname, resolve } from 'path';
+
+import { Logger, LogLevel, LogManager } from '@vlocode/core';
+import { DatapackDeployer, type DatapackDeploymentOptions } from '@vlocode/vlocity-deploy';
+import { DatapackLoader } from '@vlocode/vlocity';
+import { mapAsync, Timer } from '@vlocode/util';
+
+import { Argument, Option } from '../command';
+import { SalesforceCommand } from '../salesforceCommand';
+import {
+    createDatapackCompareReporter,
+    type DatapackCompareReportFormat
+} from '../reporters/datapackCompareReporters';
+
+type CompareCommandOptions = {
+    purgeDependencies?: boolean;
+    lookupFailed?: boolean;
+    allowUnresolved?: boolean;
+    strictOrder?: boolean;
+    continueOnError?: boolean;
+    reporter: DatapackCompareReportFormat;
+    output?: string;
+};
+
+export default class extends SalesforceCommand {
+
+    static description = 'Compare datapacks with Salesforce without deploying changes';
+
+    static args = [
+        new Argument('<paths..>', 'path of the folders containing datapacks or datapack files to compare').argParser((value, previous: string[] | undefined) => {
+            if (!existsSync(value)) {
+                throw new Error('No such folder exists');
+            }
+            return (previous ?? []).concat([ value ]);
+        })
+    ];
+
+    static options = [
+        ...SalesforceCommand.options,
+        new Option('--purge-dependencies',
+            `compare embedded dependencies as they would behave when all child records with matching keys are deleted and recreated. ` +
+            `Without this flag Vlocode only treats embedded child records without matching keys, or records with lookup skipped, as delete and recreate candidates.`
+        ).default(false),
+        new Option('--lookup-failed', 'lookup dependencies that fail to deploy in the org').default(false),
+        new Option('--allow-unresolved',
+            `do not fail comparison when a dependency cannot be resolved. ` +
+            `The comparison will continue with null dependency values where possible.`
+        ).default(false),
+        new Option('--strict-order',
+            `enforce the same strict datapack ordering rules used by deploy when resolving dependencies.`
+        ).default(false),
+        new Option('-y, --continue-on-error', 'continue comparing datapacks that can be loaded when another datapack fails to load').default(false),
+        new Option('--reporter <format>', 'report format to render').choices([ 'console', 'json', 'markdown' ]).default('console'),
+        new Option('-o, --output <file>', 'write the selected report format to a file')
+    ];
+
+    constructor(private logger: Logger = LogManager.get('DatapackCompare')) {
+        super();
+    }
+
+    public async run(paths: string[], options: CompareCommandOptions) {
+        const timer = new Timer();
+        const machineReadableStdout = !options.output && options.reporter !== 'console';
+        const previousLogLevel = LogManager.getGlobalLogLevel();
+        let report: string | undefined;
+        let result: Awaited<ReturnType<DatapackDeployer['compare']>> | undefined;
+
+        if (machineReadableStdout) {
+            LogManager.setGlobalLogLevel(LogLevel.error);
+        }
+
+        try {
+            const datapacks = await this.loadDatapacks(paths, { quiet: machineReadableStdout });
+            if (!datapacks.length) {
+                return;
+            }
+
+            const compareOptions: DatapackDeploymentOptions = {
+                strictOrder: !!options.strictOrder,
+                purgeMatchingDependencies: !!options.purgeDependencies,
+                lookupFailedDependencies: !!options.lookupFailed,
+                allowUnresolvedDependencies: !!options.allowUnresolved,
+                continueOnError: !!options.continueOnError,
+                deltaCheck: true
+            };
+
+            result = await this.container.new(DatapackDeployer).compare(datapacks, compareOptions);
+            const reporter = createDatapackCompareReporter(options.reporter);
+            report = reporter.render(result);
+        } finally {
+            if (machineReadableStdout) {
+                LogManager.setGlobalLogLevel(previousLogLevel);
+            }
+        }
+
+        if (report === undefined || result === undefined) {
+            return;
+        }
+
+        if (machineReadableStdout) {
+            process.stdout.write(`${report}\n`);
+        } else if (options.output) {
+            this.logger.info(createDatapackCompareReporter('console').render(result));
+            await this.writeReport(options.output, report);
+            this.logger.info(`Wrote ${options.reporter} comparison report to ${resolve(options.output)}`);
+        } else {
+            this.logger.info(report);
+        }
+
+        if (!machineReadableStdout) {
+            this.logger.info(`Comparison completed in ${timer.stop().toString('seconds')}`);
+        }
+    }
+
+    private async loadDatapacks(paths: string[], options: { quiet?: boolean } = {}) {
+        if (!options.quiet) {
+            this.logger.info(`Load datapacks: "${paths.join('", "')}"`);
+        }
+
+        const datapackLoadTimer = new Timer();
+        const loader = this.container.get(DatapackLoader);
+        const datapacks = (await mapAsync(paths, async path => {
+            const fileInfo = await stat(path);
+            if (fileInfo.isDirectory()) {
+                return loader.loadDatapacksFromFolder(path);
+            } else {
+                return [ await loader.loadDatapack(path) ];
+            }
+        })).flat();
+
+        if (datapacks.length == 0) {
+            this.logger.error(`No datapacks found in specified paths: "${paths.join('", "')}"`);
+        } else if (!options.quiet) {
+            this.logger.info(`Loaded ${datapacks.length} datapacks in [${datapackLoadTimer.stop()}]`);
+        }
+
+        return datapacks;
+    }
+
+    private async writeReport(file: string, contents: string) {
+        const outputFile = resolve(file);
+        await mkdir(dirname(outputFile), { recursive: true });
+        await writeFile(outputFile, contents, 'utf-8');
+    }
+}

--- a/packages/cli/src/reporters/datapackCompareReporters.test.ts
+++ b/packages/cli/src/reporters/datapackCompareReporters.test.ts
@@ -1,0 +1,110 @@
+import 'jest';
+
+import type { DatapackComparisonResult } from '@vlocode/vlocity-deploy';
+
+import {
+    DatapackCompareConsoleReporter,
+    DatapackCompareJsonReporter,
+    DatapackCompareMarkdownReporter
+} from './datapackCompareReporters';
+
+describe('Datapack compare reporters', () => {
+    const report: DatapackComparisonResult = {
+        total: 1,
+        upToDate: false,
+        datapacks: [{
+            datapack: 'Product2/Root',
+            type: 'Product2',
+            upToDate: false,
+            recordCount: 2,
+            records: [{
+                sourceKey: 'Product2/Root',
+                sobjectType: 'Product2',
+                recordId: '01t000000000001AAA',
+                upToDate: true,
+                matched: true,
+                matchedBy: 'id',
+                plannedAction: 'none',
+                touchedByDeploy: false,
+                deleteRecreate: false
+            }, {
+                sourceKey: 'Child__c/Child A',
+                sobjectType: 'Child__c',
+                upToDate: false,
+                matched: false,
+                matchedBy: 'none',
+                plannedAction: 'deleteRecreate',
+                touchedByDeploy: true,
+                deleteRecreate: true,
+                missing: true,
+                missingRecordData: [
+                    { field: 'Name', expected: 'Child A' },
+                    { field: 'Value__c', expected: 'Expected' }
+                ]
+            }],
+            mismatches: [{
+                sourceKey: 'Child__c/Child A',
+                sobjectType: 'Child__c',
+                upToDate: false,
+                matched: false,
+                matchedBy: 'none',
+                plannedAction: 'deleteRecreate',
+                touchedByDeploy: true,
+                deleteRecreate: true,
+                missing: true,
+                missingRecordData: [
+                    { field: 'Name', expected: 'Child A' },
+                    { field: 'Value__c', expected: 'Expected' }
+                ]
+            }]
+        }]
+    };
+
+    it('renders embedded missing data in the console report', () => {
+        const output = new DatapackCompareConsoleReporter().render(report);
+
+        expect(output).toContain('Product2/Root');
+        expect(output).toContain('delete + recreate');
+        expect(output).toContain('embedded record data missing from target');
+        expect(output).toContain('Value__c: Expected');
+    });
+
+    it('renders a detailed JSON report', () => {
+        const output = new DatapackCompareJsonReporter().render(report);
+        const parsed = JSON.parse(output);
+
+        expect(parsed.datapacks[0].mismatches[0]).toMatchObject({
+            sourceKey: 'Child__c/Child A',
+            plannedAction: 'deleteRecreate',
+            missingRecordData: [
+                { field: 'Name', expected: 'Child A' },
+                { field: 'Value__c', expected: 'Expected' }
+            ]
+        });
+    });
+
+    it('renders a markdown report with mismatch details', () => {
+        const output = new DatapackCompareMarkdownReporter().render(report);
+
+        expect(output).toContain('# Datapack Compare Report');
+        expect(output).toContain('| Child__c/Child A | Child__c | none |  | deleteRecreate |');
+        expect(output).toContain('| Value__c | Expected |');
+    });
+
+    it('escapes markdown headings generated from datapack source keys', () => {
+        const output = new DatapackCompareMarkdownReporter().render({
+            ...report,
+            datapacks: [{
+                ...report.datapacks[0],
+                datapack: 'Product2/Root | Variant',
+                mismatches: [{
+                    ...report.datapacks[0].mismatches[0],
+                    sourceKey: 'Child__c/Child | A'
+                }]
+            }]
+        });
+
+        expect(output).toContain('## Product2/Root \\| Variant');
+        expect(output).toContain('### Child__c/Child \\| A');
+    });
+});

--- a/packages/cli/src/reporters/datapackCompareReporters.ts
+++ b/packages/cli/src/reporters/datapackCompareReporters.ts
@@ -1,0 +1,186 @@
+import chalk from 'chalk';
+import logSymbols from 'log-symbols';
+
+import type {
+    DatapackComparisonDatapackResult,
+    DatapackComparisonResult,
+    DatapackRecordComparison
+} from '@vlocode/vlocity-deploy';
+
+export type DatapackCompareReportFormat = 'console' | 'json' | 'markdown';
+
+export interface DatapackCompareReporter {
+    readonly format: DatapackCompareReportFormat;
+    render(result: DatapackComparisonResult): string;
+}
+
+/**
+ * Human-facing report optimized for terminal scans. It shows the same underlying comparison details as
+ * JSON/Markdown, but groups them by datapack and only expands records that would be touched by deploy.
+ */
+export class DatapackCompareConsoleReporter implements DatapackCompareReporter {
+    public readonly format = 'console';
+
+    public render(result: DatapackComparisonResult): string {
+        const recordCount = result.datapacks.reduce((total, datapack) => total + datapack.recordCount, 0);
+        const mismatchCount = result.datapacks.reduce((total, datapack) => total + datapack.mismatches.length, 0);
+        const lines = new Array<string>();
+
+        lines.push(result.upToDate
+            ? `${logSymbols.success} ${chalk.green(`All ${result.total} datapacks are up to date`)} (${recordCount} records checked)`
+            : `${logSymbols.warning} ${chalk.yellow(`${mismatchCount} of ${recordCount} records would be touched across ${result.total} datapacks`)}`);
+
+        for (const datapack of result.datapacks) {
+            lines.push('');
+            lines.push(this.renderDatapackSummary(datapack));
+            for (const record of datapack.mismatches) {
+                lines.push(...this.renderRecordDetails(record).map(line => `  ${line}`));
+            }
+        }
+
+        return lines.join('\n');
+    }
+
+    private renderDatapackSummary(datapack: DatapackComparisonDatapackResult): string {
+        const status = datapack.upToDate
+            ? chalk.green('up to date')
+            : chalk.yellow(`${datapack.mismatches.length}/${datapack.recordCount} records would change`);
+        const type = datapack.type ? chalk.dim(` (${datapack.type})`) : '';
+        return `${datapack.upToDate ? logSymbols.success : logSymbols.warning} ${chalk.bold(datapack.datapack)}${type}: ${status}`;
+    }
+
+    private renderRecordDetails(record: DatapackRecordComparison): string[] {
+        const lines = [
+            `- ${chalk.bold(record.sourceKey)} ${chalk.dim(`(${record.sobjectType})`)} - ${this.renderAction(record)}`
+        ];
+
+        if (record.recordId) {
+            lines.push(`  target: ${record.recordId}`);
+        }
+        if (record.matchedBy !== 'none') {
+            lines.push(`  matched by: ${record.matchedBy}`);
+        }
+        if (record.mismatchedFields?.length) {
+            lines.push('  mismatched fields:');
+            lines.push(...record.mismatchedFields.map(field =>
+                `    ${field.field}: expected ${formatValue(field.expected)}, actual ${formatValue(field.actual)}`
+            ));
+        }
+        if (record.missingRecordData?.length) {
+            lines.push(record.deleteRecreate
+                ? '  embedded record data missing from target:'
+                : '  record data missing from target:');
+            lines.push(...record.missingRecordData.map(field =>
+                `    ${field.field}: ${formatValue(field.expected)}`
+            ));
+        }
+
+        return lines;
+    }
+
+    private renderAction(record: DatapackRecordComparison): string {
+        switch (record.plannedAction) {
+            case 'none':
+                return chalk.green('no change');
+            case 'update':
+                return chalk.yellow('update');
+            case 'insert':
+                return chalk.yellow('insert');
+            case 'deleteRecreate':
+                return chalk.yellow('delete + recreate');
+        }
+    }
+}
+
+export class DatapackCompareJsonReporter implements DatapackCompareReporter {
+    public readonly format = 'json';
+
+    public render(result: DatapackComparisonResult): string {
+        return JSON.stringify(result, null, 2);
+    }
+}
+
+/**
+ * Documentation/reporting format intended for pull requests, release notes, or audit hand-off.
+ */
+export class DatapackCompareMarkdownReporter implements DatapackCompareReporter {
+    public readonly format = 'markdown';
+
+    public render(result: DatapackComparisonResult): string {
+        const recordCount = result.datapacks.reduce((total, datapack) => total + datapack.recordCount, 0);
+        const mismatchCount = result.datapacks.reduce((total, datapack) => total + datapack.mismatches.length, 0);
+        const lines = [
+            '# Datapack Compare Report',
+            '',
+            `Status: ${result.upToDate ? 'Up to date' : 'Changes detected'}`,
+            `Datapacks: ${result.total}`,
+            `Records checked: ${recordCount}`,
+            `Records touched by deploy: ${mismatchCount}`,
+            '',
+            '| Datapack | Type | Status | Records | Touched |',
+            '| --- | --- | --- | ---: | ---: |',
+            ...result.datapacks.map(datapack =>
+                `| ${escapeMarkdown(datapack.datapack)} | ${escapeMarkdown(datapack.type)} | ${datapack.upToDate ? 'Up to date' : 'Changed'} | ${datapack.recordCount} | ${datapack.mismatches.length} |`
+            )
+        ];
+
+        for (const datapack of result.datapacks.filter(datapack => datapack.mismatches.length)) {
+            lines.push('', `## ${escapeMarkdown(datapack.datapack)}`, '');
+            lines.push('| Record | Object | Match | Target ID | Planned action |');
+            lines.push('| --- | --- | --- | --- | --- |');
+            lines.push(...datapack.mismatches.map(record =>
+                `| ${escapeMarkdown(record.sourceKey)} | ${escapeMarkdown(record.sobjectType)} | ${record.matchedBy} | ${record.recordId ?? ''} | ${record.plannedAction} |`
+            ));
+
+            for (const record of datapack.mismatches) {
+                lines.push('', `### ${escapeMarkdown(record.sourceKey)}`, '');
+                if (record.mismatchedFields?.length) {
+                    lines.push('Mismatched fields:', '');
+                    lines.push('| Field | Expected | Actual |');
+                    lines.push('| --- | --- | --- |');
+                    lines.push(...record.mismatchedFields.map(field =>
+                        `| ${escapeMarkdown(field.field)} | ${escapeMarkdown(formatValue(field.expected))} | ${escapeMarkdown(formatValue(field.actual))} |`
+                    ));
+                }
+                if (record.missingRecordData?.length) {
+                    lines.push(record.deleteRecreate ? 'Embedded record data missing from target:' : 'Record data missing from target:', '');
+                    lines.push('| Field | Expected |');
+                    lines.push('| --- | --- |');
+                    lines.push(...record.missingRecordData.map(field =>
+                        `| ${escapeMarkdown(field.field)} | ${escapeMarkdown(formatValue(field.expected))} |`
+                    ));
+                }
+            }
+        }
+
+        return lines.join('\n');
+    }
+}
+
+export function createDatapackCompareReporter(format: DatapackCompareReportFormat): DatapackCompareReporter {
+    switch (format) {
+        case 'console':
+            return new DatapackCompareConsoleReporter();
+        case 'json':
+            return new DatapackCompareJsonReporter();
+        case 'markdown':
+            return new DatapackCompareMarkdownReporter();
+    }
+}
+
+function formatValue(value: unknown): string {
+    if (value === undefined) {
+        return '<undefined>';
+    }
+    if (value === null) {
+        return '<null>';
+    }
+    if (typeof value === 'object') {
+        return JSON.stringify(value);
+    }
+    return String(value);
+}
+
+function escapeMarkdown(value: string): string {
+    return value.replaceAll('|', '\\|').replaceAll('\n', '<br>');
+}

--- a/packages/vlocity-deploy/src/__tests__/datapackComparison.test.ts
+++ b/packages/vlocity-deploy/src/__tests__/datapackComparison.test.ts
@@ -1,0 +1,291 @@
+import 'jest';
+
+import { Logger } from '@vlocode/core';
+import { SalesforceService } from '@vlocode/salesforce';
+import { VlocityNamespaceService } from '@vlocode/vlocity';
+
+import { DatapackComparator, DatapackComparisonReportBuilder, DatapackComparisonService } from '../datapackComparison';
+import { DatapackDeployment } from '../datapackDeployment';
+import { DatapackDeploymentRecord, DeploymentAction } from '../datapackDeploymentRecord';
+import { DatapackLookupService } from '../datapackLookupService';
+
+describe('Datapack comparison', () => {
+    const parentId = '01t000000000001AAA';
+
+    function field(name: string, options: Partial<{ updateable: boolean; autoNumber: boolean; formula: boolean }> = {}) {
+        return {
+            name,
+            updateable: options.updateable ?? true,
+            autoNumber: options.autoNumber ?? false,
+            formula: options.formula ?? false
+        };
+    }
+
+    function createSalesforceService(options?: {
+        lookupById?: jest.Mock,
+        lookupMultiple?: jest.Mock,
+        deleteWhere?: jest.Mock,
+        fieldsByType?: Record<string, string[]>
+    }) {
+        const fieldsByType = options?.fieldsByType ?? {
+            Product2: [ 'Name' ],
+            Child__c: [ 'Name', 'Value__c', 'Parent__c' ]
+        };
+        return {
+            schema: {
+                getSObjectFields: jest.fn(async (type: string) =>
+                    new Map((fieldsByType[type] ?? []).map(name => [ name, field(name) ]))
+                )
+            },
+            data: {
+                lookupById: options?.lookupById ?? jest.fn(async (ids: string[]) =>
+                    new Map(ids.map(id => [ id, { Id: id, Name: 'Root' } ]))
+                ),
+                lookupMultiple: options?.lookupMultiple ?? jest.fn(async () => [])
+            },
+            deleteWhere: options?.deleteWhere ?? jest.fn(async () => [])
+        } as unknown as SalesforceService;
+    }
+
+    function createLookupService(salesforce: SalesforceService) {
+        return new DatapackLookupService(
+            new VlocityNamespaceService('vlocity_cmt'),
+            salesforce,
+            Logger.null
+        );
+    }
+
+    function createComparisonService(lookupService: DatapackLookupService, salesforce: SalesforceService) {
+        return new DatapackComparisonService(
+            new DatapackComparator(lookupService, salesforce),
+            new DatapackComparisonReportBuilder(Logger.null)
+        );
+    }
+
+    function createDeployment(
+        lookupService: DatapackLookupService,
+        salesforce: SalesforceService,
+        options?: ConstructorParameters<typeof DatapackDeployment>[0],
+        connectionProvider = {} as any
+    ) {
+        return new DatapackDeployment(
+            options,
+            connectionProvider,
+            lookupService,
+            salesforce,
+            Logger.null
+        );
+    }
+
+    it('reports exact missing record data for embedded children compared through the resolved parent', async () => {
+        const lookupMultiple = jest.fn(async () => [ [] ]);
+        const salesforce = createSalesforceService({ lookupMultiple });
+        const lookupService = createLookupService(salesforce);
+        jest.spyOn(lookupService, 'lookupIds').mockImplementation(async records =>
+            records.map(record => record.sourceKey === 'Product2/Root' ? parentId : undefined)
+        );
+
+        const deployment = createDeployment(lookupService, salesforce);
+        const parent = new DatapackDeploymentRecord(
+            'Product2',
+            'Product2',
+            'Product2/Root',
+            'Product2/Root',
+            [ 'Name' ],
+            { Name: 'Root' }
+        );
+        const child = new DatapackDeploymentRecord(
+            'Product2',
+            'Child__c',
+            'Child__c/Child A',
+            'Product2/Root',
+            [],
+            { Name: 'Child A', Value__c: 'Expected' }
+        );
+        child.addLookup('Parent__c', {
+            VlocityDataPackType: 'VlocityMatchingKeyObject',
+            VlocityRecordSObjectType: 'Product2',
+            VlocityMatchingRecordSourceKey: parent.sourceKey
+        });
+        deployment.add(parent, child);
+
+        const result = await createComparisonService(lookupService, salesforce).compare(deployment);
+
+        expect(result.upToDate).toBe(false);
+        expect(lookupMultiple).toHaveBeenCalledWith(
+            'Child__c',
+            [ { Parent__c: parentId } ],
+            [ 'Name', 'Value__c', 'Parent__c' ],
+            undefined
+        );
+        const childMismatch = result.datapacks[0].mismatches.find(record => record.sourceKey === child.sourceKey);
+        expect(childMismatch).toMatchObject({
+            sourceKey: child.sourceKey,
+            sobjectType: 'Child__c',
+            upToDate: false,
+            matched: false,
+            matchedBy: 'none',
+            plannedAction: 'deleteRecreate',
+            touchedByDeploy: true,
+            deleteRecreate: true,
+            missing: true
+        });
+        expect(childMismatch?.missingRecordData).toEqual(expect.arrayContaining([
+            { field: 'Name', expected: 'Child A' },
+            { field: 'Value__c', expected: 'Expected' },
+            { field: 'Parent__c', expected: parentId }
+        ]));
+    });
+
+    it('ignores datapack fields that cannot be mapped to the target org before querying', async () => {
+        const lookupById = jest.fn(async (ids: string[]) =>
+            new Map(ids.map(id => [ id, { Id: id, Name: 'Root' } ]))
+        );
+        const salesforce = createSalesforceService({
+            lookupById,
+            fieldsByType: {
+                Product2: [ 'Name' ]
+            }
+        });
+        const lookupService = createLookupService(salesforce);
+        const record = new DatapackDeploymentRecord(
+            'Product2',
+            'Product2',
+            'Product2/Root',
+            'Product2/Root',
+            [ 'Name' ],
+            { Name: 'Root', Missing__c: 'Ignored' }
+        );
+        record.setAction(DeploymentAction.Update, parentId);
+
+        const result = await lookupService.compareRecordsToOrgData([ record ]);
+
+        expect(lookupById).toHaveBeenCalledWith([ parentId ], [ 'Name' ], undefined);
+        expect(result.get(record.sourceKey)).toMatchObject({
+            recordId: parentId,
+            inSync: true,
+            matchedBy: 'id',
+            mismatchedFields: []
+        });
+    });
+
+    it('skips embedded delete-recreate records that compare in sync by record data', async () => {
+        const childId = 'a01000000000001AAA';
+        const salesforce = createSalesforceService();
+        const lookupService = createLookupService(salesforce);
+        const deployment = createDeployment(lookupService, salesforce);
+        const child = new DatapackDeploymentRecord(
+            'Product2',
+            'Child__c',
+            'Child__c/Child A',
+            'Product2/Root',
+            [],
+            { Name: 'Child A', Value__c: 'Expected', Parent__c: parentId }
+        );
+        (deployment as any).deltaRecordStatuses = new Map([
+            [ child.sourceKey, { recordId: childId, inSync: true, matchedBy: 'recordData', deleteRecreate: true } ]
+        ]);
+
+        const batch = await (deployment as any).createDeploymentBatch(new Map([[ child.sourceKey, child ]]));
+
+        expect(child.isSkipped).toBe(true);
+        expect(child.recordId).toBe(childId);
+        expect(batch.size).toBe(0);
+    });
+
+    it('does not purge embedded dependents that are already in sync with the target org', async () => {
+        const deleteWhere = jest.fn(async () => []);
+        const salesforce = createSalesforceService({ deleteWhere });
+        const lookupService = createLookupService(salesforce);
+        const deployment = createDeployment(lookupService, salesforce, { deltaCheck: true });
+        const parent = new DatapackDeploymentRecord(
+            'Product2',
+            'Product2',
+            'Product2/Root',
+            'Product2/Root',
+            [ 'Name' ],
+            { Name: 'Root' }
+        );
+        const child = new DatapackDeploymentRecord(
+            'Product2',
+            'Child__c',
+            'Child__c/Child A',
+            'Product2/Root',
+            [],
+            { Name: 'Child A', Value__c: 'Expected' }
+        );
+        child.addLookup('Parent__c', {
+            VlocityDataPackType: 'VlocityMatchingKeyObject',
+            VlocityRecordSObjectType: 'Product2',
+            VlocityMatchingRecordSourceKey: parent.sourceKey
+        });
+        parent.setAction(DeploymentAction.Skip, parentId);
+        deployment.add(parent, child);
+        (deployment as any).deltaRecordStatuses = new Map([
+            [ child.sourceKey, { recordId: 'a01000000000001AAA', inSync: true, matchedBy: 'recordData', deleteRecreate: true } ]
+        ]);
+
+        await (deployment as any).purgeDependentRecords([ parent ], () => true);
+
+        expect(deleteWhere).not.toHaveBeenCalled();
+    });
+
+    it('runs embedded-aware delta through the full deployment loop without deleting or recreating in-sync children', async () => {
+        const childId = 'a01000000000001AAA';
+        const lookupById = jest.fn(async (ids: string[]) =>
+            new Map(ids.map(id => [ id, { Id: id, Name: 'Root' } ]))
+        );
+        const lookupMultiple = jest.fn(async () => [[
+            { Id: childId, Name: 'Child A', Value__c: 'Expected', Parent__c: parentId }
+        ]]);
+        const deleteWhere = jest.fn(async () => []);
+        const salesforce = createSalesforceService({ lookupById, lookupMultiple, deleteWhere });
+        const lookupService = createLookupService(salesforce);
+        const getJsForceConnection = jest.fn(async () => ({}));
+        jest.spyOn(lookupService, 'lookupIds').mockImplementation(async records =>
+            records.map(record => record.sourceKey === 'Product2/Root' ? parentId : undefined)
+        );
+
+        const deployment = createDeployment(
+            lookupService,
+            salesforce,
+            { deltaCheck: true },
+            { getJsForceConnection }
+        );
+        const parent = new DatapackDeploymentRecord(
+            'Product2',
+            'Product2',
+            'Product2/Root',
+            'Product2/Root',
+            [ 'Name' ],
+            { Name: 'Root' }
+        );
+        const child = new DatapackDeploymentRecord(
+            'Product2',
+            'Child__c',
+            'Child__c/Child A',
+            'Product2/Root',
+            [],
+            { Name: 'Child A', Value__c: 'Expected' }
+        );
+        child.addLookup('Parent__c', {
+            VlocityDataPackType: 'VlocityMatchingKeyObject',
+            VlocityRecordSObjectType: 'Product2',
+            VlocityMatchingRecordSourceKey: parent.sourceKey
+        });
+        deployment.add(parent, child);
+
+        await deployment.start();
+
+        expect(parent.isSkipped).toBe(true);
+        expect(child.isSkipped).toBe(true);
+        expect(child.recordId).toBe(childId);
+        expect(deleteWhere).not.toHaveBeenCalled();
+        expect(lookupMultiple).toHaveBeenCalledWith(
+            'Child__c',
+            [ { Parent__c: parentId } ],
+            [ 'Name', 'Value__c', 'Parent__c' ],
+            undefined
+        );
+    });
+});

--- a/packages/vlocity-deploy/src/datapackComparison.ts
+++ b/packages/vlocity-deploy/src/datapackComparison.ts
@@ -1,0 +1,392 @@
+import { Logger, LifecyclePolicy, injectable } from '@vlocode/core';
+import { SalesforceService } from '@vlocode/salesforce';
+import { CancellationToken, groupBy } from '@vlocode/util';
+
+import type { DatapackDeployment } from './datapackDeployment';
+import { DeploymentAction, type DatapackDeploymentRecord } from './datapackDeploymentRecord';
+import type { DatapackDeploymentRecordGroup } from './datapackDeploymentRecordGroup';
+import {
+    DatapackLookupService,
+    type OrgRecordFieldMismatch,
+    type MissingOrgRecordField,
+    type OrgRecordMatchMode,
+    type OrgRecordStatus
+} from './datapackLookupService';
+
+export type DatapackRecordPlannedAction = 'none' | 'insert' | 'update' | 'deleteRecreate';
+
+/**
+ * Record-level comparison result used by both machine reports and human-readable CLI output.
+ *
+ * `upToDate` answers the delta question, while `plannedAction` explains what a normal deploy would
+ * have done if delta did not skip it. For embedded records this distinction matters because an
+ * unchanged embedded child can otherwise be deleted and recreated simply because its parent was touched.
+ */
+export interface DatapackRecordComparison {
+    sourceKey: string;
+    sobjectType: string;
+    recordId?: string;
+    upToDate: boolean;
+    matched: boolean;
+    matchedBy: OrgRecordMatchMode;
+    plannedAction: DatapackRecordPlannedAction;
+    touchedByDeploy: boolean;
+    deleteRecreate: boolean;
+    missing?: boolean;
+    mismatchedFields?: OrgRecordFieldMismatch[];
+    missingRecordData?: MissingOrgRecordField[];
+}
+
+/**
+ * Comparison result for a single datapack root and all records expanded from that root.
+ */
+export interface DatapackComparisonDatapackResult {
+    datapack: string;
+    type: string;
+    upToDate: boolean;
+    recordCount: number;
+    records: DatapackRecordComparison[];
+    mismatches: DatapackRecordComparison[];
+}
+
+/**
+ * Top-level datapack comparison report returned by the library and rendered by CLI reporters.
+ */
+export interface DatapackComparisonResult {
+    total: number;
+    upToDate: boolean;
+    datapacks: DatapackComparisonDatapackResult[];
+}
+
+/**
+ * Compares deployment records with target org data and returns raw org-status results keyed by source key
+ * and, when available, target record Id.
+ *
+ * This class intentionally works with {@link DatapackDeploymentRecord} instances instead of neutral DTOs.
+ * The deployment model already contains dependency metadata, matching-key state, and namespace-aware values.
+ * Reusing it here keeps the standalone compare command and deploy-time delta check on the exact same
+ * resolution rules.
+ *
+ * The comparator does mutate records by resolving dependencies and setting insert/update actions. It does
+ * not perform DML and does not mark records deployed/skipped/failed. Those mutations mirror the normal
+ * deploy preparation phase so embedded-child comparisons can see the real target parent Id before deciding
+ * whether a child is already present with the same data.
+ */
+@injectable({ lifecycle: LifecyclePolicy.transient })
+export class DatapackComparator {
+
+    constructor(
+        private readonly lookupService: DatapackLookupService,
+        private readonly salesforce: SalesforceService,
+    ) {
+    }
+
+    /**
+     * Compare every deployment record against target org data.
+     *
+     * Direct records are compared by resolved target Id. Embedded records that would normally be
+     * delete/recreate candidates are compared by first restricting target rows to the resolved parent
+     * lookup, then looking for an exact data match inside that parent scope.
+     */
+    public async compareRecordStatuses(deployment: DatapackDeployment, cancelToken?: CancellationToken): Promise<Map<string, OrgRecordStatus>> {
+        const dependencyMissingRecords = await this.resolveTargetOrgIds(deployment, cancelToken);
+        return this.compareRecords(deployment, dependencyMissingRecords, cancelToken);
+    }
+
+    /**
+     * Resolve records in dependency order so embedded child filters contain target parent Id values.
+     * Records depending on parents that do not exist in the target org are marked as dependency-missing;
+     * they cannot be reliably compared to target data and will be reported as missing later.
+     */
+    private async resolveTargetOrgIds(deployment: DatapackDeployment, cancelToken?: CancellationToken) {
+        const records = deployment.getDatapacks().flatMap(group => group.records);
+        const recordsBySourceKey = new Map(records.map(record => [ record.sourceKey, record ]));
+        const unresolvedRecords = new Set(records);
+        const dependencyMissingRecords = new Set<DatapackDeploymentRecord>();
+
+        while (unresolvedRecords.size && !cancelToken?.isCancellationRequested) {
+            let madeProgress = false;
+            const lookupReadyRecords = new Array<DatapackDeploymentRecord>();
+
+            for (const record of [...unresolvedRecords]) {
+                if (this.hasMissingInternalDependency(record, recordsBySourceKey, dependencyMissingRecords)) {
+                    dependencyMissingRecords.add(record);
+                    unresolvedRecords.delete(record);
+                    madeProgress = true;
+                    continue;
+                }
+
+                await record.resolveDependencies(deployment);
+
+                if (this.hasMissingInternalDependency(record, recordsBySourceKey, dependencyMissingRecords)) {
+                    dependencyMissingRecords.add(record);
+                    unresolvedRecords.delete(record);
+                    madeProgress = true;
+                } else if (!record.hasUnresolvedDependencies) {
+                    lookupReadyRecords.push(record);
+                    unresolvedRecords.delete(record);
+                    madeProgress = true;
+                }
+            }
+
+            if (lookupReadyRecords.length) {
+                await this.resolveExistingIds(lookupReadyRecords, cancelToken);
+            }
+
+            if (!madeProgress) {
+                break;
+            }
+        }
+
+        for (const record of unresolvedRecords) {
+            dependencyMissingRecords.add(record);
+        }
+
+        return dependencyMissingRecords;
+    }
+
+    private hasMissingInternalDependency(
+        record: DatapackDeploymentRecord,
+        recordsBySourceKey: Map<string, DatapackDeploymentRecord>,
+        dependencyMissingRecords: Set<DatapackDeploymentRecord>
+    ): boolean {
+        for (const { dependency } of record.getUnresolvedDependencies('matching')) {
+            const dependencyRecord = recordsBySourceKey.get(dependency.VlocityMatchingRecordSourceKey);
+            if (dependencyRecord && (dependencyRecord.isInsert || dependencyMissingRecords.has(dependencyRecord))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Reuse the deploy lookup service so compare and deploy agree on existing record resolution.
+     */
+    private async resolveExistingIds(records: DatapackDeploymentRecord[], cancelToken?: CancellationToken) {
+        const recordsForLookup = records.filter(record => !record.skipLookup);
+        const lookupIds = await this.lookupService.lookupIds(recordsForLookup, cancelToken);
+
+        for (const record of records.filter(record => record.skipLookup)) {
+            record.setAction(DeploymentAction.Insert);
+        }
+
+        for (const [index, record] of recordsForLookup.entries()) {
+            const existingId = lookupIds[index];
+            if (existingId) {
+                record.setAction(DeploymentAction.Update, existingId);
+            } else {
+                record.setAction(DeploymentAction.Insert);
+            }
+        }
+    }
+
+    private async compareRecords(
+        deployment: DatapackDeployment,
+        dependencyMissingRecords: Set<DatapackDeploymentRecord>,
+        cancelToken?: CancellationToken
+    ): Promise<Map<string, OrgRecordStatus>> {
+        const records = deployment.getDatapacks().flatMap(group => group.records);
+        const recordStatuses = new Map<string, OrgRecordStatus>();
+        const embeddedRecreateRecords = records.filter(record =>
+            !dependencyMissingRecords.has(record) && this.shouldCompareAsEmbeddedRecreate(record, deployment)
+        );
+        const embeddedRecreateRecordSet = new Set(embeddedRecreateRecords);
+        const directRecords = records.filter(record =>
+            !dependencyMissingRecords.has(record) && !embeddedRecreateRecordSet.has(record) && record.recordId
+        );
+
+        this.setRecordStatuses(recordStatuses, await this.lookupService.compareRecordsToOrgData(directRecords, cancelToken));
+        this.setRecordStatuses(recordStatuses, await this.compareEmbeddedRecreateRecords(embeddedRecreateRecords, cancelToken));
+
+        for (const record of records) {
+            if (!recordStatuses.has(record.sourceKey)) {
+                this.setRecordStatus(recordStatuses, record, await this.lookupService.compareRecordToOrgRecords(record, []));
+            }
+        }
+
+        return recordStatuses;
+    }
+
+    /**
+     * Embedded records with no independent matching key, skipped lookup, or global purge semantics are
+     * normally recreated after their parent deploys. Those are the only embedded records that need the
+     * parent-scoped data comparison; updateable embedded records can use the direct Id delta path.
+     */
+    private shouldCompareAsEmbeddedRecreate(record: DatapackDeploymentRecord, deployment: DatapackDeployment): boolean {
+        const hasResolvedMatchingParent = record.getMatchingDependencies()
+            .some(({ field }) => !field.startsWith('$') && record.isResolved(field));
+
+        if (!hasResolvedMatchingParent) {
+            return false;
+        }
+
+        if (deployment.options.purgeMatchingDependencies) {
+            return true;
+        }
+
+        return !record.upsertFields?.length || record.skipLookup;
+    }
+
+    /**
+     * Compare delete/recreate embedded records inside their resolved parent scope.
+     *
+     * The parent filter keeps matching conservative: an embedded child under one parent should not be
+     * treated as in sync with identical-looking data under another parent. Extra target org fields and
+     * datapack fields missing from the target schema are filtered by {@link DatapackLookupService}.
+     */
+    private async compareEmbeddedRecreateRecords(records: DatapackDeploymentRecord[], cancelToken?: CancellationToken) {
+        const results = new Map<string, OrgRecordStatus>();
+        const lookupRequests = records.map(record => ({ record, filter: this.createEmbeddedParentFilter(record) }));
+
+        for (const request of lookupRequests.filter(request => !Object.keys(request.filter).length)) {
+            const status = await this.lookupService.compareRecordToOrgRecords(request.record, []);
+            this.setRecordStatus(results, request.record, { ...status, deleteRecreate: true });
+        }
+
+        for (const [sobjectType, requests] of Object.entries(groupBy(
+            lookupRequests.filter(request => Object.keys(request.filter).length),
+            request => request.record.sobjectType
+        ))) {
+            if (cancelToken?.isCancellationRequested) {
+                break;
+            }
+
+            const fields = await this.lookupService.getComparableRecordFields(
+                sobjectType,
+                requests.map(request => request.record)
+            );
+            const targetRecordGroups = await this.salesforce.data.lookupMultiple(
+                sobjectType,
+                requests.map(request => request.filter),
+                fields,
+                cancelToken
+            );
+
+            for (const [index, request] of requests.entries()) {
+                const status = await this.lookupService.compareRecordToOrgRecords(
+                    request.record,
+                    targetRecordGroups[index] ?? []
+                );
+                this.setRecordStatus(results, request.record, { ...status, deleteRecreate: true });
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Build the minimal parent lookup filter from matching dependency fields that have already been resolved.
+     */
+    private createEmbeddedParentFilter(record: DatapackDeploymentRecord): Record<string, unknown> {
+        const filter: Record<string, unknown> = {};
+        for (const { field } of record.getMatchingDependencies()) {
+            const value = record.value(field);
+            if (!field.startsWith('$') && value !== undefined && value !== null && value !== '') {
+                filter[field] = value;
+            }
+        }
+        return filter;
+    }
+
+    private setRecordStatuses(target: Map<string, OrgRecordStatus>, source: Map<string, OrgRecordStatus>) {
+        for (const [key, status] of source) {
+            target.set(key, status);
+        }
+    }
+
+    private setRecordStatus(target: Map<string, OrgRecordStatus>, record: DatapackDeploymentRecord, status: OrgRecordStatus) {
+        target.set(record.sourceKey, status);
+        const recordId = status.recordId ?? record.recordId;
+        if (recordId) {
+            target.set(recordId, status);
+        }
+    }
+}
+
+/**
+ * Converts raw org-status values into the stable report shape consumed by API callers and CLI reporters.
+ */
+@injectable({ lifecycle: LifecyclePolicy.transient })
+export class DatapackComparisonReportBuilder {
+
+    constructor(private readonly logger: Logger) {
+    }
+
+    public createDatapackResults(groups: DatapackDeploymentRecordGroup[], recordStatuses: Map<string, OrgRecordStatus>) {
+        return groups.map<DatapackComparisonDatapackResult>(group => {
+            const records = group.records.map(record => this.createRecordResult(record, recordStatuses.get(record.sourceKey)));
+            const mismatches = records.filter(record => !record.upToDate);
+            return {
+                datapack: group.key,
+                type: group.datapackType ?? '',
+                upToDate: mismatches.length === 0,
+                recordCount: records.length,
+                records,
+                mismatches
+            };
+        });
+    }
+
+    private createRecordResult(record: DatapackDeploymentRecord, status?: OrgRecordStatus): DatapackRecordComparison {
+        if (!status) {
+            this.logger.warn(`No comparison status was produced for ${record.sourceKey}; treating it as missing`);
+        }
+
+        return {
+            sourceKey: record.sourceKey,
+            sobjectType: record.sobjectType,
+            recordId: status?.recordId ?? record.recordId,
+            upToDate: status?.inSync === true,
+            matched: status?.matchedBy !== undefined && status.matchedBy !== 'none',
+            matchedBy: status?.matchedBy ?? 'none',
+            plannedAction: this.getPlannedAction(record, status),
+            touchedByDeploy: status?.inSync !== true,
+            deleteRecreate: status?.deleteRecreate === true,
+            missing: status?.missing,
+            mismatchedFields: status?.mismatchedFields,
+            missingRecordData: status?.missingRecordData
+        };
+    }
+
+    private getPlannedAction(record: DatapackDeploymentRecord, status?: OrgRecordStatus): DatapackRecordPlannedAction {
+        if (status?.inSync) {
+            return 'none';
+        }
+        if (status?.deleteRecreate) {
+            return 'deleteRecreate';
+        }
+        if (record.recordId ?? status?.recordId) {
+            return 'update';
+        }
+        return 'insert';
+    }
+}
+
+/**
+ * Facade used by public library callers. It keeps the command/API entry point small by delegating org
+ * comparison to {@link DatapackComparator} and report shaping to {@link DatapackComparisonReportBuilder}.
+ */
+@injectable({ lifecycle: LifecyclePolicy.transient })
+export class DatapackComparisonService {
+
+    constructor(
+        private readonly comparator: DatapackComparator,
+        private readonly reportBuilder: DatapackComparisonReportBuilder
+    ) {
+    }
+
+    public async compare(deployment: DatapackDeployment, cancelToken?: CancellationToken): Promise<DatapackComparisonResult> {
+        const recordStatuses = await this.compareRecordStatuses(deployment, cancelToken);
+        const datapacks = this.reportBuilder.createDatapackResults(deployment.getDatapacks(), recordStatuses);
+
+        return {
+            total: datapacks.length,
+            upToDate: datapacks.every(datapack => datapack.upToDate),
+            datapacks
+        };
+    }
+
+    public async compareRecordStatuses(deployment: DatapackDeployment, cancelToken?: CancellationToken): Promise<Map<string, OrgRecordStatus>> {
+        return this.comparator.compareRecordStatuses(deployment, cancelToken);
+    }
+}

--- a/packages/vlocity-deploy/src/datapackDeploy.ts
+++ b/packages/vlocity-deploy/src/datapackDeploy.ts
@@ -31,6 +31,27 @@ interface DatapackDeployOptions extends DatapackDeploymentOptions {
  * @returns An promise of the deployment object containing the deployment results
  */
 export async function deploy(input: string | string[], options: DatapackDeployOptions) {
+    const localContainer = await createDatapackDeployContainer(options);
+    const datapacks = await loadDatapacks(localContainer, input);
+
+    // Create deployment
+    return await localContainer.new(DatapackDeployer).deploy(datapacks, options);
+}
+
+/**
+ * Compare 1 or more datapack folders with Salesforce without deploying changes.
+ * @param input The folder(s) to load the datapacks from that will be compared
+ * @param options options that control connection and comparison behavior
+ * @returns A per-datapack comparison report
+ */
+export async function compare(input: string | string[], options: DatapackDeployOptions) {
+    const localContainer = await createDatapackDeployContainer(options);
+    const datapacks = await loadDatapacks(localContainer, input);
+
+    return await localContainer.new(DatapackDeployer).compare(datapacks, options);
+}
+
+async function createDatapackDeployContainer(options: DatapackDeployOptions) {
     const localContainer = container.create();
 
     if (options.logger) {
@@ -50,7 +71,10 @@ export async function deploy(input: string | string[], options: DatapackDeployOp
     // Setup dependencies
     localContainer.add(await new VlocityNamespaceService().initialize(localContainer.get(SalesforceConnectionProvider)));
     localContainer.add(new CachedFileSystemAdapter(new NodeFileSystem()), { provides: [ FileSystem ] });
+    return localContainer;
+}
 
+async function loadDatapacks(localContainer: ReturnType<typeof container.create>, input: string | string[]) {
     // load datapacks
     input = Array.isArray(input) ? input : [ input ];
     const datapackLoader = localContainer.new(DatapackLoader);
@@ -58,7 +82,5 @@ export async function deploy(input: string | string[], options: DatapackDeployOp
     if (datapacks.length == 0) {
         throw new Error(`No datapacks found in specified folders: ${input}`);
     }
-
-    // Create deployment
-    return await localContainer.new(DatapackDeployer).deploy(datapacks, options);
+    return datapacks;
 }

--- a/packages/vlocity-deploy/src/datapackDeployer.ts
+++ b/packages/vlocity-deploy/src/datapackDeployer.ts
@@ -1,6 +1,6 @@
 
 import { SalesforceService, RecordBatch, SalesforceConnectionProvider, Field } from '@vlocode/salesforce';
-import { Logger, injectable, container, LifecyclePolicy, Container, inject } from '@vlocode/core';
+import { Logger, injectable, LifecyclePolicy, Container, inject } from '@vlocode/core';
 import { Timer, groupBy, Iterable, CancellationToken, forEachAsyncParallel, isReadonlyArray, removeNamespacePrefix, CustomError, getErrorMessage } from '@vlocode/util';
 import { NAMESPACE_PLACEHOLDER } from './constants';
 import { DatapackDeployment } from './datapackDeployment';
@@ -11,6 +11,7 @@ import { DatapackDeploymentSpec, DeploymentSpecExecuteOptions } from './datapack
 import { DatapackDeploymentSpecRegistry } from './datapackDeploymentSpecRegistry';
 import { DatapackDeploymentEvent } from './datapackDeploymentEvent';
 import { VlocityDatapack } from '@vlocode/vlocity';
+import { DatapackComparisonService } from './datapackComparison';
 
 /**
  * Import all default deployment specs and trigger the decorators to register each sepc
@@ -117,6 +118,17 @@ export class DatapackDeployer {
     public async deploy(datapacks: VlocityDatapack[], options?: DatapackDeploymentOptions, cancellationToken?: CancellationToken) {
         const deployment = await this.createDeployment(datapacks, options, cancellationToken);
         return deployment.start(cancellationToken).then(() => deployment);
+    }
+
+    /**
+     * Compare datapacks with the target org without deploying them.
+     * @param datapacks Datapacks to compare
+     * @param options Deployment options that influence comparison behavior, such as purge matching dependencies
+     * @param cancellationToken optional cancellation token
+     */
+    public async compare(datapacks: VlocityDatapack[], options?: DatapackDeploymentOptions, cancellationToken?: CancellationToken) {
+        const deployment = await this.createDeployment(datapacks, options, cancellationToken);
+        return this.container.new(DatapackComparisonService).compare(deployment, cancellationToken);
     }
 
     /**

--- a/packages/vlocity-deploy/src/datapackDeployment.ts
+++ b/packages/vlocity-deploy/src/datapackDeployment.ts
@@ -1,7 +1,7 @@
 import { Logger, LifecyclePolicy, injectable } from '@vlocode/core';
 import { SalesforceConnectionProvider, RecordBatch, SalesforceService, RecordError } from '@vlocode/salesforce';
 import { Timer, AsyncEventEmitter, mapGetOrCreate, Iterable, CancellationToken, setMapAdd, groupBy, count, withDefaults, unique, arrayMapPush, substringBefore } from '@vlocode/util';
-import { DatapackLookupService } from './datapackLookupService';
+import { DatapackLookupService, OrgRecordStatus } from './datapackLookupService';
 import { DatapackDependencyResolver, DependencyResolutionRequest, DependencyResolutionResult } from './datapackDependencyResolver';
 import { DatapackDeploymentOptions } from './datapackDeploymentOptions';
 import { DatapackDeploymentRecord, DeploymentAction, DeploymentStatus } from './datapackDeploymentRecord';
@@ -10,6 +10,7 @@ import { DeferredDependencyResolver } from './deferredDependencyResolver';
 import { DatapackDeploymentError as Error } from './datapackDeploymentError';
 import { VlocityDatapackReference } from '@vlocode/vlocity';
 import { DatapackDeploymentDatapackStatus, DatapackDeploymentMessage, DatapackDeploymentStatus, DatapackDeploymentState } from './datapackDeploymentStatus';
+import { DatapackComparator } from './datapackComparison';
 
 export interface DatapackDeploymentEvents {
     beforeDeployRecord: Iterable<DatapackDeploymentRecord>;
@@ -95,6 +96,7 @@ export class DatapackDeployment extends AsyncEventEmitter<DatapackDeploymentEven
     private readonly recordGroups = new Map<string, DatapackDeploymentRecordGroup>();
     private readonly recordGroupsErrors = new Map<string, Error[]>();
     private readonly orgDependencyResolver: DatapackDependencyResolver;
+    private deltaRecordStatuses?: Map<string, OrgRecordStatus>;
 
     private isStarted = false;
     private timer: Timer;
@@ -685,13 +687,18 @@ export class DatapackDeployment extends AsyncEventEmitter<DatapackDeploymentEven
     }
 
     /**
-     * Compared the to be deployed records to the records in the org
+     * Create the Salesforce DML batch for records that are ready to deploy.
+     *
+     * With delta enabled this method consumes the full-deployment comparison map, not just records in
+     * the current batch. That is intentional: parent purge happens immediately after the parent batch,
+     * so embedded children must already be known as in-sync before the child batch becomes deployable.
+     *
      * @param records Records to deploy
      * @param cancelToken Cancellation token to signal the process if a cancellation is initiated
      */
     private async createDeploymentBatch(records: Map<string, DatapackDeploymentRecord>, cancelToken?: CancellationToken) {
         const batch = new RecordBatch(this.salesforceService.schema, this.options);
-        const recordStatuses = this.options.deltaCheck ? await this.getRecordSyncStatus(records.values(), cancelToken) : undefined;
+        const recordStatuses = this.options.deltaCheck ? await this.getDeltaRecordStatuses(cancelToken) : undefined;
 
         for (const [ref, record] of records.entries()) {
             if (record.isSkipped || record.isFailed) {
@@ -699,14 +706,15 @@ export class DatapackDeployment extends AsyncEventEmitter<DatapackDeploymentEven
                 continue;
             }
 
+            const status = this.getDeltaRecordStatus(record, recordStatuses);
+            if (status?.inSync) {
+                record.setAction(DeploymentAction.Skip, status.recordId ?? record.recordId);
+                continue;
+            } else if (status) {
+                this.logger.verbose(`Record out of sync ${record.recordId ?? record.sourceKey} (${record.sobjectType})`, status.mismatchedFields ?? status.missingRecordData);
+            }
+
             if (record.recordId) {
-                const status = recordStatuses?.get(record.recordId);
-                if (status?.inSync) {
-                    record.setAction(DeploymentAction.Skip);
-                    continue;
-                } else if(status) {
-                    this.logger.verbose(`Record out of sync ${record.recordId} (${record.sobjectType})`, status.mismatchedFields)
-                }
                 this.logger.debug('Update', record.sobjectType, ':', record.values);
                 batch.addUpdate(record.sobjectType, record.values, record.recordId, ref);
             } else {
@@ -719,12 +727,31 @@ export class DatapackDeployment extends AsyncEventEmitter<DatapackDeploymentEven
     }
 
     /**
-     * Compared the to be deployed records to the records in the org
-     * @param records Records
+     * Compare all deployment records to the target org once and cache the results for deploy-time delta decisions.
+     *
+     * The cache is shared by all batches so a parent batch can protect unchanged embedded children from
+     * purge before those children are deployed. The comparison is first requested after the current batch
+     * has run `beforeDeployRecord`; embedded children in later batches are compared from their converted
+     * record values plus resolved parent Ids.
+     *
      * @param cancelToken Cancellation token to signal the process if a cancellation is initiated
      */
-    private async getRecordSyncStatus(records: Iterable<DatapackDeploymentRecord>, cancelToken?: CancellationToken) {
-        return this.lookupService.compareRecordsToOrgData([...Iterable.filter(records, rec => rec.recordId && !rec.isSkipped)], cancelToken);
+    private async getDeltaRecordStatuses(cancelToken?: CancellationToken) {
+        if (!this.deltaRecordStatuses) {
+            this.deltaRecordStatuses = await new DatapackComparator(
+                this.lookupService,
+                this.salesforceService
+            ).compareRecordStatuses(this, cancelToken);
+        }
+        return this.deltaRecordStatuses;
+    }
+
+    private getDeltaRecordStatus(record: DatapackDeploymentRecord, statuses = this.deltaRecordStatuses): OrgRecordStatus | undefined {
+        return statuses?.get(record.sourceKey) ?? (record.recordId ? statuses?.get(record.recordId) : undefined);
+    }
+
+    private isDeltaRecordInSync(record: DatapackDeploymentRecord): boolean {
+        return this.getDeltaRecordStatus(record)?.inSync === true;
     }
 
     private async resolveDatapackDependencies(datapacks: Map<string, DatapackDeploymentRecord>, cancelToken?: CancellationToken): Promise<void> {
@@ -1001,6 +1028,11 @@ export class DatapackDeployment extends AsyncEventEmitter<DatapackDeploymentEven
 
         for (const [recordId, record] of recordsById.entries()) {
             for (const { record: undeployRecord, field, dependency } of dependentsBySourceKey.get(record.sourceKey) ?? []) {
+                // Delta already proved this pending embedded record exists in the target with the same
+                // field data. Deleting it here would force a no-op delete + insert cycle later.
+                if (this.options.deltaCheck && this.isDeltaRecordInSync(undeployRecord)) {
+                    continue;
+                }
                 if (predicate({ field, dependency, dependentRecord: undeployRecord, record })) {
                     setMapAdd(deleteFilters, undeployRecord.sobjectType, `${field} = '${recordId}'`);
                 }

--- a/packages/vlocity-deploy/src/datapackLookupService.ts
+++ b/packages/vlocity-deploy/src/datapackLookupService.ts
@@ -8,25 +8,50 @@ import { DatapackDeploymentRecord } from './datapackDeploymentRecord';
 import { DatapackDependencyResolver, DependencyResolutionRequest } from './datapackDependencyResolver';
 
 /**
- * Describes a records status in the target org.
+ * Field-level value difference when a matched target record exists but is not in sync.
  */
+export interface OrgRecordFieldMismatch {
+    field: string;
+    actual: any;
+    expected: any;
+}
+
 /**
- * Represents the status of a record in an org.
+ * Expected datapack field data that could not be found on any comparable target org record.
+ */
+export interface MissingOrgRecordField {
+    field: string;
+    expected: any;
+}
+
+export type OrgRecordMatchMode = 'id' | 'recordData' | 'none';
+
+/**
+ * Describes how a datapack record compares to the corresponding target org data.
  */
 export interface OrgRecordStatus {
     /**
      * Record ID in the target org.
      */
-    recordId: string;
+    recordId?: string;
     /**
      * True if the record is in sync with the target org and all fields match.
      */
     inSync: boolean;
-    mismatchedFields?: Array<{
-        field: string;
-        actual: any;
-        expected: any;
-    }>;
+    /**
+     * True when no target org record could be matched to the datapack record.
+     */
+    missing?: boolean;
+    /**
+     * Describes how the datapack record was matched to target org data.
+     */
+    matchedBy?: OrgRecordMatchMode;
+    /**
+     * True when the record is embedded data that would normally be removed and recreated during deploy.
+     */
+    deleteRecreate?: boolean;
+    mismatchedFields?: OrgRecordFieldMismatch[];
+    missingRecordData?: MissingOrgRecordField[];
 }
 
 @injectable({ lifecycle: LifecyclePolicy.transient })
@@ -374,37 +399,114 @@ export class DatapackLookupService implements DatapackDependencyResolver {
         for (const [type, records] of Object.entries(bySobjectType)) {
             this.logger.info(`Comparing record data to target org for ${records.length} ${type} records...`);
 
-            const recordFields = [...records.reduce((acc, rec) => Object.keys(rec.values).reduce((acc, field) => acc.add(field), acc), new Set<string>())];
-            const targetOrgRecords = await this.salesforce.data.lookupById(records.map(rec => rec.recordId!), recordFields, cancelToken);
             const objectFields = await this.salesforce.schema.getSObjectFields(type);
+            const recordFields = this.getComparableFields(records, objectFields);
+            const targetOrgRecords = await this.salesforce.data.lookupById(records.map(rec => rec.recordId!), recordFields, cancelToken);
 
             if (cancelToken?.isCancellationRequested) {
                 break;
             }
 
             for (const record of records) {
-                const orgData = targetOrgRecords.get(record.recordId!)!;
-                const mismatchedFields = Object.entries(record.values).map(([field, value]) => ({
-                    field,
-                    expected: value,
-                    actual: orgData[field],
-                    isEqual: this.fieldEquals(orgData, field, value)
-                })).filter(({ field, isEqual }) => !isEqual && this.isUpdateableField(objectFields.get(field)!));
-
-                const status: OrgRecordStatus = {
-                    recordId: record.recordId!,
-                    inSync: !mismatchedFields.length,
-                    mismatchedFields
-                }
+                const status = this.compareRecordToOrgData(record, targetOrgRecords.get(record.recordId!), objectFields, 'id');
 
                 results.set(record.sourceKey, status);
-                results.set(record.recordId!, status);
+                if (record.recordId) {
+                    results.set(record.recordId, status);
+                }
             }
 
             this.logger.info(`Found ${count(results.values(), item => !item.inSync) / 2} out of sync ${type} records`);
         }
 
         return results;
+    }
+
+    /**
+     * Compare one datapack record against a set of candidate target records.
+     *
+     * This is used for embedded child records where the parent lookup scopes the candidate rows but
+     * there is no stable child Id to query directly. The first candidate whose comparable datapack
+     * fields all match is treated as the existing target record.
+     *
+     * Extra fields in the org are ignored because only datapack fields are compared. Datapack fields
+     * that do not exist, or cannot be updated, in the target org are also ignored by the comparable
+     * field filter below.
+     */
+    public async compareRecordToOrgRecords(record: DatapackDeploymentRecord, targetOrgRecords: Iterable<object>): Promise<OrgRecordStatus> {
+        const objectFields = await this.salesforce.schema.getSObjectFields(record.sobjectType);
+        for (const orgData of targetOrgRecords) {
+            const status = this.compareRecordToOrgData(record, orgData, objectFields, 'recordData');
+            if (status.inSync) {
+                return status;
+            }
+        }
+        return this.createMissingRecordStatus(record, objectFields);
+    }
+
+    /**
+     * Return the minimal field list needed to compare the supplied datapack records against target data.
+     * The field list is schema-aware so comparison queries do not fail on datapack fields that are absent
+     * from the target org.
+     */
+    public async getComparableRecordFields(sobjectType: string, records: DatapackDeploymentRecord[]): Promise<string[]> {
+        return this.getComparableFields(records, await this.salesforce.schema.getSObjectFields(sobjectType));
+    }
+
+    private compareRecordToOrgData(
+        record: DatapackDeploymentRecord,
+        orgData: object | undefined,
+        objectFields: ReadonlyMap<string, Field>,
+        matchedBy: OrgRecordMatchMode = 'id'
+    ): OrgRecordStatus {
+        if (!orgData) {
+            return this.createMissingRecordStatus(record, objectFields);
+        }
+
+        const mismatchedFields = Object.entries(record.values)
+            .filter(([field]) => this.isComparableField(objectFields.get(field)))
+            .map(([field, value]) => ({
+                field,
+                expected: value,
+                actual: orgData[field],
+                isEqual: this.fieldEquals(orgData, field, value)
+            }))
+            .filter(({ isEqual }) => !isEqual)
+            .map(({ field, expected, actual }) => ({ field, expected, actual }));
+
+        return {
+            recordId: orgData['Id'] ?? record.recordId,
+            inSync: !mismatchedFields.length,
+            matchedBy,
+            mismatchedFields
+        };
+    }
+
+    private createMissingRecordStatus(record: DatapackDeploymentRecord, objectFields: ReadonlyMap<string, Field>): OrgRecordStatus {
+        return {
+            recordId: record.recordId,
+            inSync: false,
+            missing: true,
+            matchedBy: 'none',
+            missingRecordData: Object.entries(record.values)
+                .filter(([field]) => this.isComparableField(objectFields.get(field)))
+                .map(([field, expected]) => ({ field, expected }))
+        };
+    }
+
+    private getComparableFields(records: DatapackDeploymentRecord[], objectFields: ReadonlyMap<string, Field>) {
+        return [...records.reduce((acc, rec) => {
+            for (const field of Object.keys(rec.values)) {
+                if (this.isComparableField(objectFields.get(field))) {
+                    acc.add(field);
+                }
+            }
+            return acc;
+        }, new Set<string>())];
+    }
+
+    private isComparableField(field: Field | undefined): field is Field {
+        return !!field && this.isUpdateableField(field);
     }
 
     private isUpdateableField(field: Field) {

--- a/packages/vlocity-deploy/src/index.ts
+++ b/packages/vlocity-deploy/src/index.ts
@@ -24,3 +24,4 @@ export * from './datapackDeploymentStatus';
 export * from './datapackRecordFactory';
 export * from './datapackLookupService';
 export * from './matchingKeyService';
+export * from './datapackComparison';


### PR DESCRIPTION
- Add a `vlocode compare` command with console, JSON, and Markdown reports per datapack root.
- Add an embedded-aware comparator so delete/recreate child records are compared by resolved parent scope and exact record data.
- Reuse comparison status in deploy delta checks to skip unchanged embedded records and avoid unnecessary purge/recreate work.